### PR TITLE
Accept multiple queries from the query controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/spf13/afero v1.14.0
 )
 
+require github.com/microcosm-cc/bluemonday v1.0.27 // indirect
+
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
@@ -52,8 +54,7 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
-	github.com/litebase/litebase-go/sql v0.0.0-20250725191238-42aa754f0eb8 // indirect
-	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
+	github.com/litebase/litebase-go/sql v0.0.0-20250725191238-42aa754f0eb8
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/mango v0.1.0 // indirect
 	github.com/muesli/mango-cobra v1.2.0 // indirect

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"log/slog"
 	"reflect"
 	"strconv"
 	"strings"
@@ -27,6 +28,7 @@ func getValidator() *validator.Validate {
 			if name == "_" {
 				return ""
 			}
+
 			return name
 		})
 	})
@@ -67,7 +69,6 @@ func Validate(input any, messages map[string]string) map[string][]string {
 						if number, err := strconv.Atoi(part); err == nil {
 							parts[i] = "*"
 							partNumbers = append(partNumbers, number)
-							break
 						}
 					}
 
@@ -75,6 +76,7 @@ func Validate(input any, messages map[string]string) map[string][]string {
 					messageKey := fmt.Sprintf("%s.%s", wildcardKey, tag)
 
 					if messages[messageKey] == "" {
+						slog.Debug("Validation error message not found", "key", messageKey)
 						continue
 					}
 

--- a/pkg/cluster/node_message_handler.go
+++ b/pkg/cluster/node_message_handler.go
@@ -159,7 +159,7 @@ func (n *Node) handleQueryMessage(message messages.QueryMessage) interface{} {
 		Latency:         response.Latency(),
 		RowCount:        response.RowCount(),
 		Rows:            response.Rows(),
-		TransactionID:   response.TransactionId(),
+		TransactionID:   response.TransactionID(),
 		WALSequence:     response.WALSequence(),
 		WALTimestamp:    response.WALTimestamp(),
 	}

--- a/pkg/cluster/node_query_response.go
+++ b/pkg/cluster/node_query_response.go
@@ -18,10 +18,10 @@ type NodeQueryResponse interface {
 	Rows() [][]*sqlite3.Column
 	Reset()
 	SetError(err string)
-	SetId(id string)
+	SetID(id string)
 	ToMap() map[string]interface{}
 	ToJSON() ([]byte, error)
-	TransactionId() string
+	TransactionID() string
 	WALSequence() int64
 	WALTimestamp() int64
 	WriteJson(w io.Writer) error

--- a/pkg/database/builder.go
+++ b/pkg/database/builder.go
@@ -55,7 +55,7 @@ func (qb *QueryBuilder) Build(
 		auth.NewDatabaseKey(databaseId, databaseName, branchId, branchName),
 		accessKey,
 		&QueryInput{
-			Id:         id,
+			ID:         id,
 			Parameters: parameters,
 			Statement:  statement,
 		},

--- a/pkg/database/database_connection_test.go
+++ b/pkg/database/database_connection_test.go
@@ -1123,13 +1123,6 @@ func TestDatabaseConnection(t *testing.T) {
 					return err
 				}
 
-				statement, err := connection.GetConnection().Prepare(context.Background(), "INSERT INTO test (name) VALUES ('test')")
-
-				if err != nil {
-					log.Println(err)
-					return err
-				}
-
 				insertingName <- struct{}{}
 
 				<-readingName
@@ -1139,7 +1132,7 @@ func TestDatabaseConnection(t *testing.T) {
 
 				// Insert 1 row
 				err = connection.GetConnection().Transaction(false, func(con *database.DatabaseConnection) error {
-					err = statement.Sqlite3Statement.Exec(nil)
+					_, err = con.Exec("INSERT INTO test (name) VALUES ('test')", nil)
 
 					if err != nil {
 						return err

--- a/pkg/database/query_response.go
+++ b/pkg/database/query_response.go
@@ -71,7 +71,7 @@ type QueryResponse struct {
 	lastInsertRowId int64
 	rowCount        int
 	rows            [][]*sqlite3.Column
-	transactionId   string
+	transactionID   string
 	walSequence     int64
 	walTimestamp    int64
 }
@@ -126,19 +126,19 @@ func (qr *QueryResponse) Encode(responseBuffer, rowsBuffer, columnsBuffer *bytes
 	// ID
 	responseBuffer.Write([]byte(qr.id))
 	// Transaction ID length
-	var transactionIdLengthBytes [4]byte
+	var transactionIDLengthBytes [4]byte
 
-	transactionIDLenUint32, err := utils.SafeIntToUint32(len(qr.transactionId))
+	transactionIDLenUint32, err := utils.SafeIntToUint32(len(qr.transactionID))
 
 	if err != nil {
 		return nil, err
 	}
 
-	binary.LittleEndian.PutUint32(transactionIdLengthBytes[:], transactionIDLenUint32)
-	responseBuffer.Write(transactionIdLengthBytes[:])
+	binary.LittleEndian.PutUint32(transactionIDLengthBytes[:], transactionIDLenUint32)
+	responseBuffer.Write(transactionIDLengthBytes[:])
 
 	// Transaction ID
-	responseBuffer.Write([]byte(qr.transactionId))
+	responseBuffer.Write([]byte(qr.transactionID))
 
 	if len(qr.err) > 0 {
 		// Error length
@@ -331,7 +331,7 @@ func (qr *QueryResponse) MarshalJSON() ([]byte, error) {
 		LastInsertRowID: qr.lastInsertRowId,
 		RowCount:        qr.rowCount,
 		Rows:            qr.rows,
-		TransactionID:   qr.transactionId,
+		TransactionID:   qr.transactionID,
 	})
 
 	if err != nil {
@@ -350,7 +350,7 @@ func (qr *QueryResponse) Reset() {
 	qr.lastInsertRowId = 0
 	qr.rowCount = 0
 	qr.rows = qr.rows[:0]
-	qr.transactionId = ""
+	qr.transactionID = ""
 }
 
 func (qr *QueryResponse) RowCount() int {
@@ -381,7 +381,7 @@ func (qr *QueryResponse) SetError(err string) {
 	qr.err = err
 }
 
-func (qr *QueryResponse) SetId(id string) {
+func (qr *QueryResponse) SetID(id string) {
 	qr.id = id
 }
 
@@ -389,7 +389,7 @@ func (qr *QueryResponse) SetLatency(latency float64) {
 	qr.latency = latency
 }
 
-func (qr *QueryResponse) SetLastInsertRowId(lastInsertRowId int64) {
+func (qr *QueryResponse) SetLastInsertRowID(lastInsertRowId int64) {
 	qr.lastInsertRowId = lastInsertRowId
 }
 
@@ -419,8 +419,8 @@ func (qr *QueryResponse) SetRows(rows [][]*sqlite3.Column) {
 	}
 }
 
-func (qr *QueryResponse) SetTransactionId(transactionId string) {
-	qr.transactionId = transactionId
+func (qr *QueryResponse) SetTransactionID(transactionID string) {
+	qr.transactionID = transactionID
 }
 
 func (qr *QueryResponse) SetWALSequence(sequence int64) {
@@ -440,22 +440,19 @@ func (qr *QueryResponse) ToJSON() ([]byte, error) {
 
 func (qr QueryResponse) ToMap() map[string]any {
 	return map[string]any{
-		"status": "success",
-		"data": map[string]any{
-			"changes":            qr.changes,
-			"id":                 string(qr.id),
-			"latency":            qr.latency,
-			"last_insert_row_id": qr.lastInsertRowId,
-			"columns":            qr.columns,
-			"rows":               qr.rows,
-			"row_count":          qr.rowCount,
-			"transaction_id":     qr.transactionId,
-		},
+		"changes":            qr.changes,
+		"id":                 string(qr.id),
+		"latency":            qr.latency,
+		"last_insert_row_id": qr.lastInsertRowId,
+		"columns":            qr.columns,
+		"rows":               qr.rows,
+		"row_count":          qr.rowCount,
+		"transaction_id":     qr.transactionID,
 	}
 }
 
-func (qr *QueryResponse) TransactionId() string {
-	return qr.transactionId
+func (qr *QueryResponse) TransactionID() string {
+	return qr.transactionID
 }
 
 func (qr *QueryResponse) WALSequence() int64 {

--- a/pkg/database/query_response_test.go
+++ b/pkg/database/query_response_test.go
@@ -56,7 +56,7 @@ func TestNewQueryResponse(t *testing.T) {
 func TestQueryResponseEncodingWithResults(t *testing.T) {
 	// Setup test data
 	id := "query123"
-	transactionId := "txn456"
+	transactionID := "txn456"
 	columns := []string{"col1", "col2"}
 	rows := [][]*sqlite3.Column{
 		{
@@ -65,7 +65,7 @@ func TestQueryResponseEncodingWithResults(t *testing.T) {
 		},
 	}
 	qr := database.NewQueryResponse(1, columns, id, 12.34, 99, rows)
-	qr.SetTransactionId(transactionId)
+	qr.SetTransactionID(transactionID)
 
 	responseBuffer := new(bytes.Buffer)
 	rowsBuffer := new(bytes.Buffer)
@@ -105,15 +105,15 @@ func TestQueryResponseEncodingWithResults(t *testing.T) {
 	// Transaction ID length
 	txnIdLen := int(binary.LittleEndian.Uint32(encoded[offset : offset+4]))
 
-	if txnIdLen != len(transactionId) {
-		t.Errorf("expected transaction id length %d, got %d", len(transactionId), txnIdLen)
+	if txnIdLen != len(transactionID) {
+		t.Errorf("expected transaction id length %d, got %d", len(transactionID), txnIdLen)
 	}
 
 	offset += 4
 
 	// Transaction ID
-	if string(encoded[offset:offset+txnIdLen]) != string(transactionId) {
-		t.Errorf("expected transaction id %q, got %q", transactionId, encoded[offset:offset+txnIdLen])
+	if string(encoded[offset:offset+txnIdLen]) != string(transactionID) {
+		t.Errorf("expected transaction id %q, got %q", transactionID, encoded[offset:offset+txnIdLen])
 	}
 
 	offset += txnIdLen
@@ -198,10 +198,10 @@ func TestQueryResponseEncodingWithResults(t *testing.T) {
 
 func TestQueryResponseEncodingWithError(t *testing.T) {
 	id := "query123"
-	transactionId := "txn456"
+	transactionID := "txn456"
 	errorMsg := "something went wrong"
 	qr := database.NewQueryResponse(0, nil, id, 0, 0, nil)
-	qr.SetTransactionId(transactionId)
+	qr.SetTransactionID(transactionID)
 	qr.SetError(errorMsg)
 
 	responseBuffer := new(bytes.Buffer)
@@ -236,14 +236,14 @@ func TestQueryResponseEncodingWithError(t *testing.T) {
 
 	// Transaction ID length
 	txnIdLen := int(binary.LittleEndian.Uint32(encoded[offset : offset+4]))
-	if txnIdLen != len(transactionId) {
-		t.Errorf("expected transaction id length %d, got %d", len(transactionId), txnIdLen)
+	if txnIdLen != len(transactionID) {
+		t.Errorf("expected transaction id length %d, got %d", len(transactionID), txnIdLen)
 	}
 	offset += 4
 
 	// Transaction ID
-	if string(encoded[offset:offset+txnIdLen]) != string(transactionId) {
-		t.Errorf("expected transaction id %q, got %q", transactionId, encoded[offset:offset+txnIdLen])
+	if string(encoded[offset:offset+txnIdLen]) != string(transactionID) {
+		t.Errorf("expected transaction id %q, got %q", transactionID, encoded[offset:offset+txnIdLen])
 	}
 	offset += txnIdLen
 
@@ -288,9 +288,9 @@ func BenchmarkQueryResponseJsonEncoding(b *testing.B) {
 
 		queryResponse.SetChanges(0)
 		queryResponse.SetColumns([]string{"id", "name"})
-		queryResponse.SetId("id")
+		queryResponse.SetID("id")
 		queryResponse.SetLatency(0.01)
-		queryResponse.SetLastInsertRowId(1)
+		queryResponse.SetLastInsertRowID(1)
 		queryResponse.SetRowCount(2)
 		queryResponse.SetRows([][]*sqlite3.Column{
 			{sqlite3.NewColumn(sqlite3.ColumnTypeText, []byte("1")), sqlite3.NewColumn(sqlite3.ColumnTypeText, []byte("name1"))},

--- a/pkg/database/query_test.go
+++ b/pkg/database/query_test.go
@@ -26,7 +26,7 @@ func TestNewQuery(t *testing.T) {
 					Type:  "INTEGER",
 					Value: int64(1),
 				}},
-				Id: "query123",
+				ID: "query123",
 			},
 		)
 
@@ -65,7 +65,7 @@ func TestResolve(t *testing.T) {
 					Type:  "INTEGER",
 					Value: int64(1),
 				}},
-				Id: "query123",
+				ID: "query123",
 			},
 		)
 

--- a/pkg/database/resolver.go
+++ b/pkg/database/resolver.go
@@ -56,7 +56,7 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 			transaction, err = query.databaseManager.Resources(
 				query.DatabaseKey.DatabaseID,
 				query.DatabaseKey.DatabaseBranchID,
-			).TransactionManager().Get(string(query.Input.TransactionId))
+			).TransactionManager().Get(string(query.Input.TransactionID))
 
 			if err != nil {
 				return nil, err
@@ -68,7 +68,7 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 			transaction, err = query.databaseManager.Resources(
 				query.DatabaseKey.DatabaseID,
 				query.DatabaseKey.DatabaseBranchID,
-			).TransactionManager().Get(string(query.Input.TransactionId))
+			).TransactionManager().Get(string(query.Input.TransactionID))
 
 			if err != nil {
 				return nil, err
@@ -132,14 +132,14 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 			}
 		}
 
-		response.SetId(query.Input.Id)
+		response.SetID(query.Input.ID)
 		response.SetLatency(float64(time.Since(start)) / float64(time.Millisecond))
 
 		if transaction != nil || query.IsTransactional() {
 			if transaction != nil {
-				response.SetTransactionId(transaction.Id)
+				response.SetTransactionID(transaction.ID)
 			} else {
-				response.SetTransactionId(query.transaction.Id)
+				response.SetTransactionID(query.transaction.ID)
 			}
 		}
 
@@ -150,7 +150,7 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 		}
 
 		response.SetChanges(changes)
-		response.SetLastInsertRowId(lastInsertRowID)
+		response.SetLastInsertRowID(lastInsertRowID)
 
 		if sqlite3Result != nil {
 			response.SetColumns(sqlite3Result.Columns)
@@ -209,7 +209,7 @@ func forwardQueryToPrimary(query *Query, response *QueryResponse) (*QueryRespons
 				AccessKeyID: query.AccessKey.AccessKeyID,
 				BranchID:    query.DatabaseKey.DatabaseBranchID,
 				DatabaseID:  query.DatabaseKey.DatabaseID,
-				ID:          query.Input.Id,
+				ID:          query.Input.ID,
 				Statement:   query.Input.Statement,
 				Parameters:  query.Input.Parameters,
 			},
@@ -230,9 +230,9 @@ func forwardQueryToPrimary(query *Query, response *QueryResponse) (*QueryRespons
 		response.SetChanges(primaryResponse.Changes)
 		response.SetColumns(primaryResponse.Columns)
 		response.SetError(primaryResponse.Error)
-		response.SetId(primaryResponse.ID)
+		response.SetID(primaryResponse.ID)
 		response.SetLatency(primaryResponse.Latency)
-		response.SetLastInsertRowId(primaryResponse.LastInsertRowID)
+		response.SetLastInsertRowID(primaryResponse.LastInsertRowID)
 		response.SetRowCount(primaryResponse.RowCount)
 		response.SetRows(primaryResponse.Rows)
 		response.SetWALSequence(primaryResponse.WALSequence)

--- a/pkg/database/resolver_test.go
+++ b/pkg/database/resolver_test.go
@@ -64,7 +64,7 @@ func TestQueryResolver_Handle(t *testing.T) {
 				&database.QueryInput{
 					Statement:  c.statement,
 					Parameters: c.parameters,
-					Id:         "",
+					ID:         "",
 				},
 			)
 

--- a/pkg/database/transaction.go
+++ b/pkg/database/transaction.go
@@ -25,7 +25,7 @@ type Transaction struct {
 	databaseKey      *auth.DatabaseKey
 	databaseManager  *DatabaseManager
 	EndedAt          time.Time
-	Id               string
+	ID               string
 	queryChannel     chan TransactionQuery
 	StartedAt        time.Time
 	responseChannel  chan *QueryResponse
@@ -62,7 +62,7 @@ func NewTransaction(
 		connection:      connection,
 		databaseKey:     databaseKey,
 		databaseManager: databaseManager,
-		Id:              uuid.NewString(),
+		ID:              uuid.NewString(),
 		CreatedAt:       time.Now().UTC(),
 		queryChannel:    make(chan TransactionQuery, 1),
 		responseChannel: make(chan *QueryResponse, 1),
@@ -164,7 +164,7 @@ func (t *Transaction) ResolveQuery(query *Query, response *QueryResponse) error 
 
 	<-t.responseChannel
 
-	if response.id != query.Input.Id {
+	if response.id != query.Input.ID {
 		return ErrInvalidTransactionResponse
 	}
 

--- a/pkg/database/transaction_manager.go
+++ b/pkg/database/transaction_manager.go
@@ -44,7 +44,7 @@ func (d *TransactionManager) Create(
 	}
 
 	d.mutex.Lock()
-	d.transactions[transaction.Id] = transaction
+	d.transactions[transaction.ID] = transaction
 	d.mutex.Unlock()
 
 	return transaction, nil

--- a/pkg/http/query_controller.go
+++ b/pkg/http/query_controller.go
@@ -8,6 +8,10 @@ import (
 	"golang.org/x/exp/slog"
 )
 
+type QueryRequest struct {
+	Queries []*database.QueryInput `json:"queries" validate:"required,dive"`
+}
+
 func QueryController(request *Request) Response {
 	databaseKey, errResponse := request.DatabaseKey()
 
@@ -48,81 +52,90 @@ func QueryController(request *Request) Response {
 
 	defer request.databaseManager.ConnectionManager().Release(db)
 
-	input := &database.QueryInput{}
-
-	err = input.DecodeFromMap(request.All())
+	queries, err := request.Input(&QueryRequest{})
 
 	if err != nil {
 		slog.Error("failed to parse input", "error", err.Error())
+
 		return BadRequestResponse(ErrInvalidInput)
 	}
 
 	// Validate the input
-	validationErrors := request.Validate(input, map[string]string{
-		"id.required":                 "The query ID field is required.",
-		"parameters.required":         "The parameters field is required.",
-		"parameters.*.type.required":  "The parameter type field is required.",
-		"parameters.*.type.oneof":     "The parameter type field must be one of the allowed values.",
-		"parameters.*.value.required": "The parameter value field is required.",
-		"statement.required":          "The SQL statement field is required.",
+	validationErrors := request.Validate(queries, map[string]string{
+		"queries.*.id.required":                        "The query ID field is required.",
+		"queries.*.parameters.required":                "The parameters field is required.",
+		"queries.*.parameters.*.type.required":         "The parameter type field is required.",
+		"queries.*.parameters.*.type.oneof":            "The parameter type field must be one of the allowed values.",
+		"queries.*.parameters.*.value.required":        "The parameter value field is required.",
+		"queries.*.parameters.*.value.required_unless": "The parameter value field is required unless the type is NULL.",
+		"queries.*.statement.required":                 "The SQL statement field is required.",
+		"queries.*.transaction_id.required":            "The transaction ID field is required.",
 	})
 
 	if validationErrors != nil {
 		return ValidationErrorResponse(validationErrors)
 	}
+	responses := []map[string]any{}
 
-	requestQuery := database.GetQuery(
-		request.cluster,
-		request.databaseManager,
-		request.logManager,
-		databaseKey,
-		accessKey,
-		input,
-	)
+	for _, query := range queries.(*QueryRequest).Queries {
+		requestQuery := database.GetQuery(
+			request.cluster,
+			request.databaseManager,
+			request.logManager,
+			databaseKey,
+			accessKey,
+			query,
+		)
 
-	defer database.PutQuery(requestQuery)
+		defer database.PutQuery(requestQuery)
 
-	response := &database.QueryResponse{}
+		response := &database.QueryResponse{}
 
-	if requestQuery.Input.TransactionId != "" &&
-		!requestQuery.IsTransactionEnd() &&
-		!requestQuery.IsTransactionRollback() {
-		transaction, err := request.databaseManager.Resources(
-			databaseKey.DatabaseID,
-			databaseKey.DatabaseBranchID,
-		).TransactionManager().Get(string(requestQuery.Input.TransactionId))
+		if requestQuery.Input.TransactionID != "" &&
+			!requestQuery.IsTransactionEnd() &&
+			!requestQuery.IsTransactionRollback() {
+			transaction, err := request.databaseManager.Resources(
+				databaseKey.DatabaseID,
+				databaseKey.DatabaseBranchID,
+			).TransactionManager().Get(string(requestQuery.Input.TransactionID))
 
-		if err != nil {
-			return JsonResponse(map[string]interface{}{
-				"message": err.Error(),
-			}, 500, nil,
-			)
+			if err != nil {
+				return JsonResponse(map[string]interface{}{
+					"message": err.Error(),
+				}, 500, nil,
+				)
+			}
+
+			if accessKey.AccessKeyID != transaction.AccessKey.AccessKeyID {
+				return ErrInvalidAccessKeyResponse
+			}
+
+			err = transaction.ResolveQuery(requestQuery, response)
+
+			if err != nil {
+				return JsonResponse(map[string]interface{}{
+					"message": err.Error(),
+				}, 500, nil,
+				)
+			}
+		} else {
+			_, err = requestQuery.Resolve(response)
+
+			if err != nil {
+				return JsonResponse(map[string]interface{}{
+					"message": err.Error(),
+				}, 500, nil)
+			}
 		}
 
-		if accessKey.AccessKeyID != transaction.AccessKey.AccessKeyID {
-			return ErrInvalidAccessKeyResponse
-		}
-
-		err = transaction.ResolveQuery(requestQuery, response)
-
-		if err != nil {
-			return JsonResponse(map[string]interface{}{
-				"message": err.Error(),
-			}, 500, nil,
-			)
-		}
-	} else {
-		_, err = requestQuery.Resolve(response)
-
-		if err != nil {
-			return JsonResponse(map[string]interface{}{
-				"message": err.Error(),
-			}, 500, nil)
-		}
+		responses = append(responses, response.ToMap())
 	}
 
 	return Response{
 		StatusCode: 200,
-		Body:       response.ToMap(),
+		Body: map[string]any{
+			"status": "success",
+			"data":   responses,
+		},
 	}
 }

--- a/pkg/http/query_stream_controller.go
+++ b/pkg/http/query_stream_controller.go
@@ -117,13 +117,13 @@ func processInput(
 
 	defer database.PutQuery(requestQuery)
 
-	if requestQuery.Input.TransactionId != "" &&
+	if requestQuery.Input.TransactionID != "" &&
 		!requestQuery.IsTransactionEnd() &&
 		!requestQuery.IsTransactionRollback() {
 		transaction, err = request.databaseManager.Resources(
 			databaseKey.DatabaseID,
 			databaseKey.DatabaseBranchID,
-		).TransactionManager().Get(string(requestQuery.Input.TransactionId))
+		).TransactionManager().Get(string(requestQuery.Input.TransactionID))
 
 		if err != nil {
 			return err
@@ -297,19 +297,21 @@ func handleQueryStreamRequest(
 	}
 
 	validationErrors := validation.Validate(queryInput, map[string]string{
-		"id.required":                 "The query ID field is required.",
-		"parameters.required":         "The parameters field is required.",
-		"parameters.*.type.required":  "The parameter type field is required.",
-		"parameters.*.type.oneof":     "The parameter type field must be one of the allowed values.",
-		"parameters.*.value.required": "The parameter value field is required.",
-		"statement.required":          "The SQL statement field is required.",
-		"statement.min":               "The SQL statement field must be at least 1 character long.",
+		"id.required":                        "The query ID field is required.",
+		"parameters.required":                "The parameters field is required.",
+		"parameters.*.type.required":         "The parameter type field is required.",
+		"parameters.*.type.oneof":            "The parameter type field must be one of the allowed values.",
+		"parameters.*.value.required":        "The parameter value field is required.",
+		"parameters.*.value.required_unless": "The parameter value field is required unless the type is NULL.",
+		"statement.required":                 "The SQL statement field is required.",
+		"statement.min":                      "The SQL statement field must be at least 1 character long.",
+		"transaction_id.required":            "The transaction ID field is required.",
 	})
 
 	if validationErrors != nil {
 		jsonValidationErrors, _ := json.Marshal(validationErrors)
 
-		response.SetId(queryInput.Id)
+		response.SetID(queryInput.ID)
 		response.SetError(fmt.Sprintf("Invalid input: %s", jsonValidationErrors))
 
 		responseBytes, _ := response.Encode(responseBuffer, rowsBuffer, columnsBuffer)

--- a/pkg/http/transaction_commit_controller.go
+++ b/pkg/http/transaction_commit_controller.go
@@ -57,7 +57,7 @@ func TransactionCommitController(request *Request) Response {
 		return BadRequestResponse(err)
 	}
 
-	defer transactionManager.Remove(transaction.Id)
+	defer transactionManager.Remove(transaction.ID)
 
 	err = transaction.Commit()
 

--- a/pkg/http/transaction_commit_controller_test.go
+++ b/pkg/http/transaction_commit_controller_test.go
@@ -85,13 +85,17 @@ func TestTransactionCommitController(t *testing.T) {
 				fmt.Sprintf("/v1/databases/%s/%s/query", database.DatabaseName, database.BranchName),
 				"POST",
 				map[string]any{
-					"id":             uuid.NewString(),
-					"transaction_id": transactionId,
-					"statement":      "INSERT INTO test (id, value) VALUES (?, ?)",
-					"parameters": []map[string]any{
+					"queries": []map[string]any{
 						{
-							"type":  "TEXT",
-							"value": "test",
+							"id":             uuid.NewString(),
+							"transaction_id": transactionId,
+							"statement":      "INSERT INTO test (id, value) VALUES (?, ?)",
+							"parameters": []map[string]any{
+								{
+									"type":  "TEXT",
+									"value": "test",
+								},
+							},
 						},
 					},
 				},
@@ -115,10 +119,14 @@ func TestTransactionCommitController(t *testing.T) {
 				fmt.Sprintf("/v1/databases/%s/%s/query", database.DatabaseName, database.BranchName),
 				"POST",
 				map[string]any{
-					"id":             uuid.NewString(),
-					"transaction_id": transactionId,
-					"statement":      "SELECT COUNT(*) FROM test",
-					"parameters":     []map[string]any{},
+					"queries": []map[string]any{
+						{
+							"id":             uuid.NewString(),
+							"transaction_id": transactionId,
+							"statement":      "SELECT COUNT(*) FROM test",
+							"parameters":     []map[string]any{},
+						},
+					},
 				},
 			)
 
@@ -135,7 +143,7 @@ func TestTransactionCommitController(t *testing.T) {
 				t.Errorf("Unexpected response: %v", countResponse)
 			}
 
-			data, ok := countResponse["data"].(map[string]any)
+			data, ok := countResponse["data"].([]any)[0].(map[string]any)
 
 			if !ok {
 				t.Fatal("Count response data is not a map")

--- a/pkg/http/transaction_controller.go
+++ b/pkg/http/transaction_controller.go
@@ -59,7 +59,7 @@ func TransactionControllerStore(request *Request) Response {
 			"status":  "success",
 			"message": "Transaction created successfully",
 			"data": map[string]any{
-				"id":          transaction.Id,
+				"id":          transaction.ID,
 				"database_id": databaseKey.DatabaseID,
 				"branch_id":   databaseKey.DatabaseBranchID,
 				"created_at":  transaction.CreatedAt,
@@ -115,7 +115,7 @@ func TransactionControllerDestroy(request *Request) Response {
 		return BadRequestResponse(err)
 	}
 
-	defer transactionManager.Remove(transaction.Id)
+	defer transactionManager.Remove(transaction.ID)
 
 	err = transaction.Rollback()
 

--- a/pkg/http/transaction_controller_test.go
+++ b/pkg/http/transaction_controller_test.go
@@ -216,7 +216,7 @@ func TestTransactionController_2(t *testing.T) {
 				"POST",
 				map[string]any{
 					"queries": []map[string]any{
-						map[string]any{
+						{
 							"id":             uuid.NewString(),
 							"transaction_id": transactionId,
 							"statement":      "SELECT COUNT(*) FROM test",

--- a/pkg/http/transaction_controller_test.go
+++ b/pkg/http/transaction_controller_test.go
@@ -181,13 +181,17 @@ func TestTransactionController_2(t *testing.T) {
 				fmt.Sprintf("/v1/databases/%s/%s/query", database.DatabaseName, database.BranchName),
 				"POST",
 				map[string]any{
-					"id":             uuid.NewString(),
-					"transaction_id": transactionId,
-					"statement":      "INSERT INTO test (id, value) VALUES (?, ?)",
-					"parameters": []map[string]any{
+					"queries": []map[string]any{
 						{
-							"type":  "TEXT",
-							"value": "test",
+							"id":             uuid.NewString(),
+							"transaction_id": transactionId,
+							"statement":      "INSERT INTO test (id, value) VALUES (?, ?)",
+							"parameters": []map[string]any{
+								{
+									"type":  "TEXT",
+									"value": "test",
+								},
+							},
 						},
 					},
 				},
@@ -211,10 +215,14 @@ func TestTransactionController_2(t *testing.T) {
 				fmt.Sprintf("/v1/databases/%s/%s/query", database.DatabaseName, database.BranchName),
 				"POST",
 				map[string]any{
-					"id":             uuid.NewString(),
-					"transaction_id": transactionId,
-					"statement":      "SELECT COUNT(*) FROM test",
-					"parameters":     []map[string]any{},
+					"queries": []map[string]any{
+						map[string]any{
+							"id":             uuid.NewString(),
+							"transaction_id": transactionId,
+							"statement":      "SELECT COUNT(*) FROM test",
+							"parameters":     []map[string]any{},
+						},
+					},
 				},
 			)
 
@@ -231,7 +239,7 @@ func TestTransactionController_2(t *testing.T) {
 				t.Errorf("Unexpected response: %v", countResponse)
 			}
 
-			data, ok := countResponse["data"].(map[string]any)
+			data, ok := countResponse["data"].([]any)[0].(map[string]any)
 
 			if !ok {
 				t.Fatal("Count response data is not a map")

--- a/pkg/sqlite3/parameter.go
+++ b/pkg/sqlite3/parameter.go
@@ -32,7 +32,7 @@ var jsonParameterDecoderPool = JsonParameterDecoderPool()
 
 type StatementParameter struct {
 	Type  string `json:"type" validate:"required,oneof=TEXT INTEGER FLOAT BLOB NULL"`
-	Value any    `json:"value" validate:"required"`
+	Value any    `json:"value" validate:"required_unless=Type NULL"`
 }
 
 func (sp StatementParameter) Encode(buffer *bytes.Buffer) []byte {


### PR DESCRIPTION
Guess I should start making PRs now that this thing is public 😅 

The current implementation of the `QueryController` has been to accept a single query at a time. This limits the client from sending batch requests over JSON.

```HTTP
POST /v1/databases/test/main/query HTTP 1.1 

Content-Type: application/json

{
    "id": "123",
    "statement": "INSERT INTO users (username) VALUES (?)",
    "parameters" : ["johndoe"]
}
```

The goal is to allow this endpoint to accept batch requests. So now, clients will need to send all queries under the `queries` property.

```HTTP
POST /v1/databases/test/main/query HTTP 1.1 

Content-Type: application/json

{
    "queries": [
        {
            "id": "123",
            "statement": "INSERT INTO users (username) VALUES (?)",
            "parameters" : ["johndoe"]
        }
    ]
```