### PR TITLE
Add commands to view database snapshots

### DIFF
--- a/pkg/cli/cmd/database.go
+++ b/pkg/cli/cmd/database.go
@@ -20,6 +20,7 @@ func NewDatabaseCmd(config *config.CLIConfiguration) *cobra.Command {
 	cmd.AddCommand(NewDatabaseBackupCmd(config))
 	cmd.AddCommand(NewDatabaseBranchCmd(config))
 	cmd.AddCommand(NewDatabaseRestoreCmd(config))
+	cmd.AddCommand(NewDatabaseSnapshotCmd(config))
 	cmd.AddCommand(NewDatabaseUpdateCmd(config))
 	cmd.AddCommand(NewDatabaseQueryCmd(config))
 	cmd.AddCommand(NewDatabaseQueryLogCmd(config))

--- a/pkg/cli/cmd/database_snapshot.go
+++ b/pkg/cli/cmd/database_snapshot.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/litebase/litebase/pkg/cli/config"
+	"github.com/spf13/cobra"
+)
+
+func NewDatabaseSnapshotCmd(config *config.CLIConfiguration) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "snapshot",
+		Short: "View database snapshots",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cmd.Help()
+
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	cmd.AddCommand(NewDatabaseSnapshotListCmd(config))
+	cmd.AddCommand(NewDatabaseSnapshotShowCmd(config))
+
+	return cmd
+}

--- a/pkg/cli/cmd/database_snapshot_list.go
+++ b/pkg/cli/cmd/database_snapshot_list.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/litebase/litebase/pkg/cli/api"
+	"github.com/litebase/litebase/pkg/cli/components"
+	"github.com/litebase/litebase/pkg/cli/config"
+
+	"github.com/spf13/cobra"
+)
+
+func NewDatabaseSnapshotListCmd(config *config.CLIConfiguration) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list <database/branch>",
+		Args:  cobra.ExactArgs(1),
+		Short: "List database snapshots",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			databaseName, branchName, err := splitDatabasePath(args[0])
+
+			if err != nil {
+				return fmt.Errorf("invalid database path: %w", err)
+			}
+
+			data, err := api.Get(config, fmt.Sprintf("/v1/databases/%s/%s/snapshots", databaseName, branchName))
+
+			if err != nil {
+				return err
+			}
+
+			if data["data"] == nil {
+				rows := [][]string{}
+
+				_, err = lipgloss.Fprint(
+					cmd.OutOrStdout(),
+					components.Container(
+						components.NewTable([]string{"Date (UTC)", "Restore Points", "Start Restore Point", "Last Restore Point"}, rows).
+							Render(config.GetInteractive()),
+					),
+				)
+
+				return err
+			}
+
+			rows := [][]string{}
+
+			for _, snapshot := range data["data"].([]any) {
+				snapshotData := snapshot.(map[string]any)
+
+				// Convert timestamp to UTC date for display
+				var dateUTC string
+				if ts, ok := snapshotData["timestamp"].(float64); ok {
+					t := time.Unix(0, int64(ts)).UTC()
+					dateUTC = t.Format("2006-01-02 15:04:05")
+				} else {
+					dateUTC = "Unknown"
+				}
+
+				restorePointsCount := "0"
+				startRestorePoint := "-"
+				lastRestorePoint := "-"
+
+				if restorePoints, exists := snapshotData["restore_points"]; exists && restorePoints != nil {
+					if rpMap, ok := restorePoints.(map[string]any); ok {
+						if total, totalExists := rpMap["total"]; totalExists {
+							restorePointsCount = fmt.Sprintf("%v", total)
+						}
+						if start, startExists := rpMap["start"]; startExists {
+							if startInt, ok := start.(float64); ok {
+								startTime := time.Unix(0, int64(startInt)).UTC()
+								startRestorePoint = startTime.Format("2006-01-02 15:04:05")
+							}
+						}
+						if end, endExists := rpMap["end"]; endExists {
+							if endInt, ok := end.(float64); ok {
+								endTime := time.Unix(0, int64(endInt)).UTC()
+								lastRestorePoint = endTime.Format("2006-01-02 15:04:05")
+							}
+						}
+					}
+				}
+
+				rows = append(rows, []string{
+					dateUTC,
+					restorePointsCount,
+					startRestorePoint,
+					lastRestorePoint,
+				})
+			}
+
+			_, err = lipgloss.Fprint(
+				cmd.OutOrStdout(),
+				components.Container(
+					components.NewTable([]string{"Date (UTC)", "Restore Points", "Start Restore Point", "Last Restore Point"}, rows).
+						Render(config.GetInteractive()),
+				),
+			)
+
+			return err
+		},
+	}
+}

--- a/pkg/cli/cmd/database_snapshot_list_test.go
+++ b/pkg/cli/cmd/database_snapshot_list_test.go
@@ -1,0 +1,213 @@
+package cmd_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/litebase/litebase/internal/test"
+	"github.com/litebase/litebase/pkg/auth"
+	"github.com/litebase/litebase/pkg/database"
+)
+
+func TestDatabaseSnapshotList(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		testDatabase := test.MockDatabase(server.App)
+
+		db, err := server.App.DatabaseManager.ConnectionManager().Get(testDatabase.DatabaseID, testDatabase.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("failed to get database connection: %v", err)
+		}
+
+		defer server.App.DatabaseManager.ConnectionManager().Release(db)
+
+		if err := db.GetConnection().Checkpoint(); err != nil {
+			t.Fatalf("failed to create checkpoint: %v", err)
+		}
+
+		_, err = db.GetConnection().Exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)", nil)
+
+		if err != nil {
+			t.Fatalf("failed to create test table: %v", err)
+		}
+
+		if err := db.GetConnection().Checkpoint(); err != nil {
+			t.Fatalf("failed to create checkpoint: %v", err)
+		}
+
+		err = db.GetConnection().Transaction(false, func(db *database.DatabaseConnection) error {
+			_, err = db.Exec("INSERT INTO test (value) VALUES ('test data')", nil)
+			return err
+		})
+
+		if err != nil {
+			t.Fatalf("failed to insert data: %v", err)
+		}
+
+		if err := db.GetConnection().Checkpoint(); err != nil {
+			t.Fatalf("failed to create final checkpoint: %v", err)
+		}
+
+		err = cli.Run("database", "snapshot", "list", fmt.Sprintf("%s/%s", testDatabase.DatabaseName, testDatabase.BranchName))
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Check that snapshot information is displayed
+		if cli.DoesntSee("Date (UTC)") {
+			t.Error("expected output to contain 'Date (UTC)' column header")
+		}
+
+		if cli.DoesntSee("Restore Points") {
+			t.Error("expected output to contain 'Restore Points' column header")
+		}
+
+		if cli.DoesntSee("Start Restore Point") {
+			t.Error("expected output to contain 'Start Restore Point' column header")
+		}
+
+		if cli.DoesntSee("Last Restore Point") {
+			t.Error("expected output to contain 'Last Restore Point' column header")
+		}
+
+		// Check that we have date format (YYYY-MM-DD HH:MM:SS) instead of timestamp
+		// Calculate the expected date for today's start of day
+		startOfDay := time.Now().UTC().Truncate(24 * time.Hour)
+		expectedDate := startOfDay.Format("2006-01-02")
+
+		if cli.DoesntSee(expectedDate) { // Should contain today's date
+			t.Errorf("expected output to contain date %s", expectedDate)
+		}
+
+		if cli.DoesntSee("3") { // Restore points count
+			t.Error("expected output to contain restore points count")
+		}
+	})
+}
+
+func TestDatabaseSnapshotListNonExistentDatabase(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run("database", "snapshot", "list", "non-existent-database/main")
+
+		if err == nil {
+			t.Error("expected error when listing snapshots for non-existent database, got none")
+		}
+	})
+}
+
+func TestDatabaseSnapshotListNonExistentBranch(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		testDatabase := test.MockDatabase(server.App)
+
+		err := cli.Run("database", "snapshot", "list", fmt.Sprintf("%s/non-existent-branch", testDatabase.DatabaseName))
+
+		if err == nil {
+			t.Error("expected error when listing snapshots for non-existent branch, got none")
+		}
+	})
+}
+
+func TestDatabaseSnapshotListInvalidPath(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run("database", "snapshot", "list", "invalid-path-format")
+
+		if err == nil {
+			t.Error("expected error when using invalid path format, got none")
+		}
+	})
+}
+
+func TestDatabaseSnapshotListMissingArguments(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run("database", "snapshot", "list")
+
+		if err == nil {
+			t.Error("expected error when no database/branch path provided, got none")
+		}
+	})
+}
+
+func TestDatabaseSnapshotListAccessControl(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		testDatabase := test.MockDatabase(server.App)
+
+		// Create CLI with limited access (similar to controller test pattern)
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{
+					Effect:   auth.StatementEffectAllow,
+					Resource: "*",
+					Actions:  []auth.Privilege{auth.DatabasePrivilegeBackup},
+				},
+			})
+
+		err := cli.Run("database", "snapshot", "list", fmt.Sprintf("%s/%s", testDatabase.DatabaseName, testDatabase.BranchName))
+
+		// The key test is that we don't get a permission denied error
+		if err != nil {
+			if cli.Sees("Forbidden") || cli.Sees("permission") {
+				t.Fatalf("expected no permission error, got %v", err)
+			}
+
+			// If we get "Failed to get snapshots", that might be because there are no snapshots
+			// which is acceptable for this access control test
+			t.Logf("Command failed (possibly due to no snapshots): %v", err)
+		} else {
+			// If successful, should show table headers
+			if cli.DoesntSee("Timestamp") {
+				t.Error("expected output to contain 'Timestamp' column header")
+			}
+		}
+	})
+}

--- a/pkg/cli/cmd/database_snapshot_show.go
+++ b/pkg/cli/cmd/database_snapshot_show.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/litebase/litebase/pkg/cli/api"
+	"github.com/litebase/litebase/pkg/cli/components"
+	"github.com/litebase/litebase/pkg/cli/config"
+
+	"github.com/spf13/cobra"
+)
+
+func NewDatabaseSnapshotShowCmd(config *config.CLIConfiguration) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <database/branch> <timestamp>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Get a database snapshot",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			databaseName, branchName, err := splitDatabasePath(args[0])
+
+			if err != nil {
+				return fmt.Errorf("invalid database path: %w", err)
+			}
+
+			timestamp := args[1]
+
+			res, err := api.Get(config, fmt.Sprintf("/v1/databases/%s/%s/snapshots/%s", databaseName, branchName, timestamp))
+
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprint(
+				cmd.OutOrStdout(),
+				components.Container(
+					components.DatabaseSnapshotCard(
+						res["data"].(map[string]any),
+					),
+				),
+			)
+
+			return err
+		},
+	}
+}

--- a/pkg/cli/cmd/database_snapshot_show_test.go
+++ b/pkg/cli/cmd/database_snapshot_show_test.go
@@ -1,0 +1,291 @@
+package cmd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/litebase/litebase/internal/test"
+	"github.com/litebase/litebase/pkg/auth"
+	"github.com/litebase/litebase/pkg/backups"
+	"github.com/litebase/litebase/pkg/database"
+)
+
+func TestDatabaseSnapshotShow(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		testDatabase := test.MockDatabase(server.App)
+		snapshotLogger := server.App.DatabaseManager.Resources(testDatabase.DatabaseID, testDatabase.DatabaseBranchID).SnapshotLogger()
+
+		db, err := server.App.DatabaseManager.ConnectionManager().Get(testDatabase.DatabaseID, testDatabase.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("failed to get database connection: %v", err)
+		}
+
+		defer server.App.DatabaseManager.ConnectionManager().Release(db)
+
+		// Create an initial checkpoint to create a snapshot
+		if err := db.GetConnection().Checkpoint(); err != nil {
+			t.Fatalf("failed to create checkpoint: %v", err)
+		}
+
+		// Create a test table and insert some data
+		_, err = db.GetConnection().Exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)", nil)
+
+		if err != nil {
+			t.Fatalf("failed to create test table: %v", err)
+		}
+
+		if err := db.GetConnection().Checkpoint(); err != nil {
+			t.Fatalf("failed to create checkpoint: %v", err)
+		}
+
+		// Insert a row
+		err = db.GetConnection().Transaction(false, func(db *database.DatabaseConnection) error {
+			_, err = db.Exec("INSERT INTO test (value) VALUES ('test data')", nil)
+			return err
+		})
+
+		if err != nil {
+			t.Fatalf("failed to insert data: %v", err)
+		}
+
+		if err := db.GetConnection().Checkpoint(); err != nil {
+			t.Fatalf("failed to create final checkpoint: %v", err)
+		}
+
+		// Get a snapshot to show
+		snapshots, err := snapshotLogger.GetSnapshots()
+
+		if err != nil {
+			t.Fatalf("failed to get snapshots: %v", err)
+		}
+
+		if len(snapshots) == 0 {
+			t.Fatalf("expected at least one snapshot, got none")
+		}
+
+		// Use the first snapshot
+		var snapshot *backups.Snapshot
+		for _, s := range snapshots {
+			snapshot = s
+			break
+		}
+
+		err = cli.Run("database", "snapshot", "show", fmt.Sprintf("%s/%s", testDatabase.DatabaseName, testDatabase.BranchName), fmt.Sprintf("%d", snapshot.Timestamp))
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Debug: Print actual output to see what we get
+		output := cli.GetOutput()
+		t.Logf("Show output: %s", output)
+		t.Logf("Looking for timestamp: %d", snapshot.Timestamp)
+
+		// Check that snapshot information is displayed
+		if cli.DoesntSee("Database Snapshot") {
+			t.Error("expected output to contain 'Database Snapshot' card title")
+		}
+
+		// Check for timestamp
+		timestampStr := fmt.Sprintf("%d", snapshot.Timestamp)
+		if cli.DoesntSee(timestampStr) {
+			t.Errorf("expected output to contain timestamp %s", timestampStr)
+		}
+
+		if cli.DoesntSee(testDatabase.DatabaseID) {
+			t.Error("expected output to contain database ID")
+		}
+
+		if cli.DoesntSee(testDatabase.DatabaseBranchID) {
+			t.Error("expected output to contain branch ID")
+		}
+
+		// Check for restore points table
+		if cli.DoesntSee("Restore Points") {
+			t.Error("expected output to contain 'Restore Points' section title")
+		}
+
+		if cli.DoesntSee("Time (UTC)") {
+			t.Error("expected output to contain 'Time (UTC)' column header in restore points table")
+		}
+	})
+}
+
+func TestDatabaseSnapshotShowNonExistentSnapshot(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		testDatabase := test.MockDatabase(server.App)
+
+		err := cli.Run("database", "snapshot", "show", fmt.Sprintf("%s/%s", testDatabase.DatabaseName, testDatabase.BranchName), "999999999")
+
+		if err == nil {
+			t.Error("expected error when showing non-existent snapshot, got none")
+		}
+	})
+}
+
+func TestDatabaseSnapshotShowNonExistentDatabase(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run("database", "snapshot", "show", "non-existent-database/main", "123456789")
+
+		if err == nil {
+			t.Error("expected error when showing snapshot from non-existent database, got none")
+		}
+	})
+}
+
+func TestDatabaseSnapshotShowNonExistentBranch(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		testDatabase := test.MockDatabase(server.App)
+
+		err := cli.Run("database", "snapshot", "show", fmt.Sprintf("%s/non-existent-branch", testDatabase.DatabaseName), "123456789")
+
+		if err == nil {
+			t.Error("expected error when showing snapshot from non-existent branch, got none")
+		}
+	})
+}
+
+func TestDatabaseSnapshotShowInvalidPath(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run("database", "snapshot", "show", "invalid-path-format", "123456789")
+
+		if err == nil {
+			t.Error("expected error when using invalid path format, got none")
+		}
+	})
+}
+
+func TestDatabaseSnapshotShowMissingArguments(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		// Test missing both arguments
+		err := cli.Run("database", "snapshot", "show")
+
+		if err == nil {
+			t.Error("expected error when no arguments provided, got none")
+		}
+
+		// Test missing timestamp argument
+		testDatabase := test.MockDatabase(server.App)
+		err = cli.Run("database", "snapshot", "show", fmt.Sprintf("%s/%s", testDatabase.DatabaseName, testDatabase.BranchName))
+
+		if err == nil {
+			t.Error("expected error when no timestamp provided, got none")
+		}
+	})
+}
+
+func TestDatabaseSnapshotShowAccessControl(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		testDatabase := test.MockDatabase(server.App)
+		snapshotLogger := server.App.DatabaseManager.Resources(testDatabase.DatabaseID, testDatabase.DatabaseBranchID).SnapshotLogger()
+
+		// Create a snapshot first
+		db, err := server.App.DatabaseManager.ConnectionManager().Get(testDatabase.DatabaseID, testDatabase.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("failed to get database connection: %v", err)
+		}
+
+		defer server.App.DatabaseManager.ConnectionManager().Release(db)
+
+		if err := db.GetConnection().Checkpoint(); err != nil {
+			t.Fatalf("failed to create checkpoint: %v", err)
+		}
+
+		snapshots, err := snapshotLogger.GetSnapshots()
+
+		if err != nil {
+			t.Fatalf("failed to get snapshots: %v", err)
+		}
+
+		if len(snapshots) == 0 {
+			t.Fatalf("expected at least one snapshot, got none")
+		}
+
+		var snapshot *backups.Snapshot
+		for _, s := range snapshots {
+			snapshot = s
+			break
+		}
+
+		// Create CLI with limited access (similar to controller test pattern)
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{
+					Effect:   auth.StatementEffectAllow,
+					Resource: "*",
+					Actions:  []auth.Privilege{auth.DatabasePrivilegeBackup},
+				},
+			})
+
+		err = cli.Run("database", "snapshot", "show", fmt.Sprintf("%s/%s", testDatabase.DatabaseName, testDatabase.BranchName), fmt.Sprintf("%d", snapshot.Timestamp))
+
+		if err != nil {
+			t.Fatalf("expected no error with proper access, got %v", err)
+		}
+
+		// Should be able to see the snapshot details
+		if cli.DoesntSee("Database Snapshot") {
+			t.Error("expected output to contain 'Database Snapshot' card title")
+		}
+	})
+}

--- a/pkg/cli/cmd/database_snapshot_test.go
+++ b/pkg/cli/cmd/database_snapshot_test.go
@@ -1,0 +1,39 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/litebase/litebase/internal/test"
+	"github.com/litebase/litebase/pkg/auth"
+)
+
+func TestDatabaseSnapshot(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run("database", "snapshot")
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if cli.DoesntSee("View database snapshots") {
+			t.Error("expected output to contain 'View database snapshots'")
+		}
+
+		if cli.DoesntSee("list") {
+			t.Error("expected output to contain 'list'")
+		}
+
+		if cli.DoesntSee("show") {
+			t.Error("expected output to contain 'show'")
+		}
+	})
+}

--- a/pkg/cli/components/database_snapshot_card.go
+++ b/pkg/cli/components/database_snapshot_card.go
@@ -1,0 +1,105 @@
+package components
+
+import (
+	"fmt"
+	"time"
+)
+
+func DatabaseSnapshotCard(data map[string]any) string {
+	// Handle timestamp as int64 to avoid scientific notation
+	var timestampStr string
+
+	if ts, ok := data["timestamp"].(float64); ok {
+		timestampStr = fmt.Sprintf("%.0f", ts)
+	} else {
+		timestampStr = fmt.Sprintf("%v", data["timestamp"])
+	}
+
+	rows := []CardRow{
+		{
+			Key:   "Timestamp",
+			Value: timestampStr,
+		},
+		{
+			Key:   "Database ID",
+			Value: data["database_id"].(string),
+		},
+		{
+			Key:   "Branch ID",
+			Value: data["database_branch_id"].(string),
+		},
+	}
+
+	// Add restore points summary information
+	var restorePointsTable string
+	if restorePoints, exists := data["restore_points"]; exists && restorePoints != nil {
+		if rpMap, ok := restorePoints.(map[string]any); ok {
+			if total, totalExists := rpMap["total"]; totalExists {
+				rows = append(rows, CardRow{
+					Key:   "Total Restore Points",
+					Value: fmt.Sprintf("%v", total),
+				})
+			}
+			if start, startExists := rpMap["start"]; startExists {
+				if startInt, ok := start.(float64); ok {
+					startTime := time.Unix(0, int64(startInt)).UTC()
+					rows = append(rows, CardRow{
+						Key:   "Earliest Restore Point",
+						Value: startTime.Format(time.RFC3339),
+					})
+				}
+			}
+
+			if end, endExists := rpMap["end"]; endExists {
+				if endInt, ok := end.(float64); ok {
+					endTime := time.Unix(0, int64(endInt)).UTC()
+					rows = append(rows, CardRow{
+						Key:   "Latest Restore Point",
+						Value: endTime.Format(time.RFC3339),
+					})
+				}
+			}
+
+			// Create table of all restore points if data array exists
+			if rpData, dataExists := rpMap["data"]; dataExists {
+				if dataArray, ok := rpData.([]any); ok && len(dataArray) > 0 {
+					restorePointRows := [][]string{}
+					
+					for i, rp := range dataArray {
+						if rpTimestamp, ok := rp.(float64); ok {
+							timestamp := fmt.Sprintf("%.0f", rpTimestamp)
+							rpTime := time.Unix(0, int64(rpTimestamp)).UTC()
+							timeFormatted := rpTime.Format(time.RFC3339)
+							
+							restorePointRows = append(restorePointRows, []string{
+								fmt.Sprintf("%d", i+1),
+								timestamp,
+								timeFormatted,
+							})
+						}
+					}
+					
+					if len(restorePointRows) > 0 {
+						restorePointsTable = NewTable(
+							[]string{"#", "Timestamp", "Time (UTC)"},
+							restorePointRows,
+						).Render(true) // Always render interactive for better formatting
+					}
+				}
+			}
+		}
+	}
+
+	card := NewCard(
+		WithCardTitle("Database Snapshot"),
+		WithCardRows(rows),
+	).Render()
+
+	// If we have restore points table, append it with a proper title
+	if restorePointsTable != "" {
+		restorePointsTitle := CardTitleStyle().Render("Restore Points")
+		card += "\n\n" + restorePointsTitle + "\n\n" + restorePointsTable
+	}
+
+	return card
+}

--- a/pkg/cli/components/table.go
+++ b/pkg/cli/components/table.go
@@ -86,6 +86,7 @@ func NewTable(
 
 	// Assign weights based on column types and content
 	weights := make([]float64, len(columns))
+
 	for i, title := range columns {
 		switch title {
 		case "#", "No", "Index":


### PR DESCRIPTION
## Snapshot Commands

Add commands to view the snapshots of a database and the restore points within the snapshots.



**Snapshot List**

```
litebase database snapshot list <database>/<branch>
```

Will display a list of snapshots.


**Snapshot Show**
```
litebase database snapshot show <database>/<branch> <timestamp>
```

Will display a list of restore points in the snapshot.