### PR TITLE
Database Restore Command

### DIFF
--- a/pkg/cli/cmd/database_restore.go
+++ b/pkg/cli/cmd/database_restore.go
@@ -2,20 +2,117 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/litebase/litebase/pkg/cli/api"
+	"github.com/litebase/litebase/pkg/cli/components"
 	"github.com/litebase/litebase/pkg/cli/config"
 	"github.com/spf13/cobra"
 )
 
 func NewDatabaseRestoreCmd(config *config.CLIConfiguration) *cobra.Command {
-	return &cobra.Command{
-		Use:   "restore <name>",
-		Args:  cobra.ExactArgs(1),
-		Short: "Restore a database",
+	cmd := &cobra.Command{
+		Use:   "restore <source-database/branch> <target-database/branch>",
+		Args:  cobra.ExactArgs(2),
+		Short: "Restore a database from a specific timestamp",
+		Long:  "Restore a database from a specific timestamp to a target database and branch.\n\nThe timestamp should be a Unix timestamp in nanoseconds (int64).\nYou can get available timestamps from the 'database snapshot show' command.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("Database restored:", args[0])
+			sourceDatabaseName, sourceBranchName, err := splitDatabasePath(args[0])
 
-			return nil
+			if err != nil {
+				return fmt.Errorf("invalid source database path: %w", err)
+			}
+
+			targetDatabaseName, targetBranchName, err := splitDatabasePath(args[1])
+
+			if err != nil {
+				return fmt.Errorf("invalid target database path: %w", err)
+			}
+
+			timestampStr, err := cmd.Flags().GetString("timestamp")
+
+			if err != nil {
+				return fmt.Errorf("failed to get timestamp: %w", err)
+			}
+
+			if timestampStr == "" {
+				return fmt.Errorf("timestamp is required")
+			}
+
+			_, err = strconv.ParseInt(timestampStr, 10, 64)
+
+			if err != nil {
+				return fmt.Errorf("invalid timestamp format - must be a Unix timestamp in nanoseconds: %w", err)
+			}
+
+			requestData := map[string]any{
+				"target_database":        targetDatabaseName,
+				"target_database_branch": targetBranchName,
+				"timestamp":              timestampStr,
+			}
+
+			res, apiErrors, err := api.Post(
+				config,
+				fmt.Sprintf("/v1/databases/%s/%s/restore", sourceDatabaseName, sourceBranchName),
+				requestData,
+			)
+
+			if err != nil {
+				return err
+			}
+
+			if len(apiErrors) > 0 {
+				return fmt.Errorf("failed to restore database: %v", apiErrors)
+			}
+
+			rows := []components.CardRow{
+				{
+					Key:   "Source Database",
+					Value: fmt.Sprintf("%s/%s", sourceDatabaseName, sourceBranchName),
+				},
+				{
+					Key:   "Target Database",
+					Value: fmt.Sprintf("%s/%s", targetDatabaseName, targetBranchName),
+				},
+				{
+					Key:   "Timestamp",
+					Value: timestampStr,
+				},
+			}
+
+			if status, ok := res["status"].(string); ok {
+				rows = append(rows, components.CardRow{
+					Key:   "Status",
+					Value: status,
+				})
+			}
+
+			if message, ok := res["message"].(string); ok {
+				rows = append(rows, components.CardRow{
+					Key:   "Message",
+					Value: message,
+				})
+			}
+
+			_, err = lipgloss.Fprint(
+				cmd.OutOrStdout(),
+				components.Container(
+					components.SuccessAlert("Database restore completed successfully"),
+					components.NewCard(
+						components.WithCardTitle("Database Restore"),
+						components.WithCardRows(rows),
+					).Render(),
+				),
+			)
+
+			return err
 		},
 	}
+
+	cmd.Flags().String("timestamp", "", "Unix timestamp in nanoseconds to restore from (required)")
+
+	cmd.MarkFlagRequired("timestamp")
+
+	return cmd
 }

--- a/pkg/cli/cmd/database_restore_test.go
+++ b/pkg/cli/cmd/database_restore_test.go
@@ -1,0 +1,305 @@
+package cmd_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/litebase/litebase/internal/test"
+	"github.com/litebase/litebase/pkg/auth"
+	"github.com/litebase/litebase/pkg/backups"
+	"github.com/litebase/litebase/pkg/database"
+)
+
+func TestDatabaseRestoreSuccess(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		sourceDB := test.MockDatabase(server.App)
+		snapshotLogger := server.App.DatabaseManager.Resources(sourceDB.DatabaseID, sourceDB.DatabaseBranchID).SnapshotLogger()
+
+		db, err := server.App.DatabaseManager.ConnectionManager().Get(sourceDB.DatabaseID, sourceDB.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("failed to get database connection: %v", err)
+		}
+
+		defer server.App.DatabaseManager.ConnectionManager().Release(db)
+
+		// Create initial checkpoint
+		if err := db.GetConnection().Checkpoint(); err != nil {
+			t.Fatalf("failed to create checkpoint: %v", err)
+		}
+
+		// Create a test table and insert data
+		_, err = db.GetConnection().Exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)", nil)
+
+		if err != nil {
+			t.Fatalf("failed to create test table: %v", err)
+		}
+
+		if err := db.GetConnection().Checkpoint(); err != nil {
+			t.Fatalf("failed to create checkpoint: %v", err)
+		}
+
+		// Insert test data in a transaction
+		err = db.GetConnection().Transaction(false, func(db *database.DatabaseConnection) error {
+			_, err = db.Exec("INSERT INTO test (value) VALUES ('restore test data')", nil)
+			return err
+		})
+
+		if err != nil {
+			t.Fatalf("failed to insert data: %v", err)
+		}
+
+		// Create final checkpoint to establish restore point
+		if err := db.GetConnection().Checkpoint(); err != nil {
+			t.Fatalf("failed to create final checkpoint: %v", err)
+		}
+
+		// Get the snapshots to find a restore point timestamp
+		snapshots, err := snapshotLogger.GetSnapshots()
+
+		if err != nil {
+			t.Fatalf("failed to get snapshots: %v", err)
+		}
+
+		if len(snapshots) == 0 {
+			t.Fatal("no snapshots available")
+		}
+
+		// Use the first snapshot's timestamp
+		var snapshot *backups.Snapshot
+
+		for _, s := range snapshots {
+			snapshot = s
+			break
+		}
+
+		timestamp := snapshot.Timestamp
+
+		// Create target database
+		targetDB := test.MockDatabase(server.App)
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err = cli.Run(
+			"database", "restore",
+			fmt.Sprintf("%s/%s", sourceDB.DatabaseName, sourceDB.BranchName),
+			fmt.Sprintf("%s/%s", targetDB.DatabaseName, targetDB.BranchName),
+			"--timestamp", strconv.FormatInt(timestamp, 10),
+		)
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if cli.DoesNotSee("Database restore completed successfully") {
+			t.Error("expected output to contain success message")
+		}
+
+		if cli.DoesNotSee(fmt.Sprintf("%s/%s", sourceDB.DatabaseName, sourceDB.BranchName)) {
+			t.Error("expected output to contain source database name")
+		}
+
+		if cli.DoesNotSee(fmt.Sprintf("%s/%s", targetDB.DatabaseName, targetDB.BranchName)) {
+			t.Error("expected output to contain target database name")
+		}
+
+		if cli.DoesNotSee(strconv.FormatInt(timestamp, 10)) {
+			t.Error("expected output to contain timestamp")
+		}
+	})
+}
+
+func TestDatabaseRestoreMissingFlags(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		sourceDB := test.MockDatabase(server.App)
+		targetDB := test.MockDatabase(server.App)
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run(
+			"database", "restore",
+			fmt.Sprintf("%s/%s", sourceDB.DatabaseName, sourceDB.BranchName),
+			fmt.Sprintf("%s/%s", targetDB.DatabaseName, targetDB.BranchName),
+		)
+
+		if err == nil {
+			t.Error("expected error when timestamp flag is missing, got none")
+		}
+	})
+}
+
+func TestDatabaseRestoreInvalidTimestamp(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		sourceDB := test.MockDatabase(server.App)
+		targetDB := test.MockDatabase(server.App)
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run(
+			"database", "restore",
+			fmt.Sprintf("%s/%s", sourceDB.DatabaseName, sourceDB.BranchName),
+			fmt.Sprintf("%s/%s", targetDB.DatabaseName, targetDB.BranchName),
+			"--timestamp", "invalid-timestamp",
+		)
+
+		if err == nil {
+			t.Error("expected error when timestamp format is invalid, got none")
+		}
+
+		// Test empty timestamp
+		err = cli.Run(
+			"database", "restore",
+			fmt.Sprintf("%s/%s", sourceDB.DatabaseName, sourceDB.BranchName),
+			fmt.Sprintf("%s/%s", targetDB.DatabaseName, targetDB.BranchName),
+			"--timestamp", "",
+		)
+
+		if err == nil {
+			t.Error("expected error when timestamp is empty, got none")
+		}
+	})
+}
+
+func TestDatabaseRestoreInvalidDatabasePath(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		targetDB := test.MockDatabase(server.App)
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run(
+			"database", "restore", "invalid-path",
+			fmt.Sprintf("%s/%s", targetDB.DatabaseName, targetDB.BranchName),
+			"--timestamp", "1699123456789012345",
+		)
+
+		if err == nil {
+			t.Error("expected error when source database path is invalid, got none")
+		}
+
+		err = cli.Run(
+			"database", "restore",
+			fmt.Sprintf("%s/%s", targetDB.DatabaseName, targetDB.BranchName),
+			"invalid-target-path",
+			"--timestamp", "1699123456789012345",
+		)
+
+		if err == nil {
+			t.Error("expected error when target database path is invalid, got none")
+		}
+	})
+}
+
+func TestDatabaseRestoreNonExistentSourceDatabase(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		targetDB := test.MockDatabase(server.App)
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run(
+			"database", "restore", "non-existent-db/main",
+			fmt.Sprintf("%s/%s", targetDB.DatabaseName, targetDB.BranchName),
+			"--timestamp", "1699123456789012345",
+		)
+
+		if err == nil {
+			t.Error("expected error when source database does not exist, got none")
+		}
+	})
+}
+
+func TestDatabaseRestoreInsufficientPrivileges(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		sourceDB := test.MockDatabase(server.App)
+		targetDB := test.MockDatabase(server.App)
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{auth.DatabasePrivilegeRead}},
+			})
+
+		err := cli.Run(
+			"database", "restore",
+			fmt.Sprintf("%s/%s", sourceDB.DatabaseName, sourceDB.BranchName),
+			fmt.Sprintf("%s/%s", targetDB.DatabaseName, targetDB.BranchName),
+			"--timestamp", "1699123456789012345",
+		)
+
+		if err == nil {
+			t.Error("expected error when user lacks restore privileges, got none")
+		}
+	})
+}
+
+func TestDatabaseRestoreWrongArgumentCount(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run("database", "restore")
+
+		if err == nil {
+			t.Error("expected error when no arguments provided, got none")
+		}
+
+		err = cli.Run("database", "restore", "source-db/main")
+
+		if err == nil {
+			t.Error("expected error when only one argument provided, got none")
+		}
+
+		err = cli.Run(
+			"database", "restore", "source-db/main", "target-db/main", "extra-arg",
+			"--timestamp", "1699123456789012345",
+		)
+
+		if err == nil {
+			t.Error("expected error when too many arguments provided, got none")
+		}
+	})
+}

--- a/pkg/http/database_restore_controller.go
+++ b/pkg/http/database_restore_controller.go
@@ -94,6 +94,17 @@ func DatabaseRestoreController(request *Request) Response {
 	sourceDfs := request.databaseManager.Resources(database.DatabaseID, branch.DatabaseBranchID).FileSystem()
 	targetDfs := request.databaseManager.Resources(targetDatabase.DatabaseID, targetBranch.DatabaseBranchID).FileSystem()
 
+	// Validate that the target database branch is empty before restoring
+	targetSize, err := targetDfs.Size()
+
+	if err != nil {
+		return ServerErrorResponse(fmt.Errorf("failed to check target database size: %w", err))
+	}
+
+	if targetSize > 0 {
+		return BadRequestResponse(fmt.Errorf("target database branch '%s/%s' is not empty (size: %d bytes). Restore can only be performed on empty database branches", targetDatabaseName, targetBranchName, targetSize))
+	}
+
 	err = backups.RestoreFromTimestamp(
 		request.cluster.Config,
 		request.cluster.TieredFS(),

--- a/pkg/http/database_restore_controller_test.go
+++ b/pkg/http/database_restore_controller_test.go
@@ -3,6 +3,7 @@ package http_test
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/litebase/litebase/internal/test"
@@ -425,6 +426,170 @@ func TestDatabaseRestoreControllerMultiple(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Expected no error, got %v", err)
 			}
+		}
+	})
+}
+
+func TestDatabaseRestoreControllerNonEmptyTarget(t *testing.T) {
+	test.Run(t, func() {
+		// Force immediate compaction for testing
+		originalInterval := storage.GetPageLoggerCompactInterval()
+		storage.SetPageLoggerCompactInterval(0)
+		defer func() {
+			storage.SetPageLoggerCompactInterval(originalInterval)
+		}()
+
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		source := test.MockDatabase(server.App)
+		target := test.MockDatabase(server.App)
+
+		// Set up source database with data
+		sourceDb, err := server.App.DatabaseManager.ConnectionManager().Get(source.DatabaseID, source.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		defer server.App.DatabaseManager.ConnectionManager().Release(sourceDb)
+
+		// Create initial checkpoint
+		err = server.App.DatabaseManager.ConnectionManager().ForceCheckpoint(source.DatabaseID, source.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Create table and data in source
+		_, err = sourceDb.GetConnection().Exec("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)", nil)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Force checkpoint to create restore point
+		err = server.App.DatabaseManager.ConnectionManager().ForceCheckpoint(source.DatabaseID, source.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Insert data in source
+		err = sourceDb.GetConnection().Transaction(false, func(db *database.DatabaseConnection) error {
+			_, err = db.Exec("INSERT INTO test (value) VALUES ('source data')", nil)
+			return err
+		})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Final checkpoint to establish restore point
+		err = server.App.DatabaseManager.ConnectionManager().ForceCheckpoint(source.DatabaseID, source.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Set up target database with existing data (make it non-empty)
+		targetDb, err := server.App.DatabaseManager.ConnectionManager().Get(target.DatabaseID, target.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		defer server.App.DatabaseManager.ConnectionManager().Release(targetDb)
+
+		// Add data to target database to make it non-empty
+		_, err = targetDb.GetConnection().Exec("CREATE TABLE existing (id INTEGER PRIMARY KEY, data TEXT)", nil)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		err = targetDb.GetConnection().Transaction(false, func(db *database.DatabaseConnection) error {
+			_, err = db.Exec("INSERT INTO existing (data) VALUES ('existing data')", nil)
+			return err
+		})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Force checkpoint on target to ensure data is persisted
+		err = server.App.DatabaseManager.ConnectionManager().ForceCheckpoint(target.DatabaseID, target.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Get restore point from source
+		snapshotLogger := server.App.DatabaseManager.Resources(source.DatabaseID, source.DatabaseBranchID).SnapshotLogger()
+		snapshotKeys := snapshotLogger.Keys()
+
+		if len(snapshotKeys) == 0 {
+			t.Fatal("No snapshots found")
+		}
+
+		snapshot, err := snapshotLogger.GetSnapshot(snapshotKeys[len(snapshotKeys)-1])
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if len(snapshot.RestorePoints.Data) == 0 {
+			t.Fatal("No restore points found")
+		}
+
+		// Use the last restore point
+		restorePointTimestamp := snapshot.RestorePoints.End
+		restorePoint, err := snapshot.GetRestorePoint(restorePointTimestamp)
+
+		if err != nil {
+			t.Fatalf("Expected no error getting restore point for timestamp %d, got %v", restorePointTimestamp, err)
+		}
+
+		// Attempt to restore to non-empty target - should fail
+		client := server.WithAccessKeyClient([]auth.Statement{
+			{
+				Effect:   "Allow",
+				Resource: "*",
+				Actions:  []auth.Privilege{auth.DatabasePrivilegeRestore},
+			},
+		})
+
+		resp, responseCode, err := client.Send(
+			fmt.Sprintf(
+				"/v1/databases/%s/%s/restore",
+				source.DatabaseName,
+				source.BranchName,
+			),
+			"POST",
+			map[string]any{
+				"target_database":        target.DatabaseName,
+				"target_database_branch": target.BranchName,
+				"timestamp":              strconv.FormatInt(restorePoint.Timestamp, 10),
+			},
+		)
+
+		if err != nil {
+			t.Fatalf("Failed to make request: %v", err)
+		}
+
+		// Should return 400 Bad Request due to non-empty target
+		if responseCode != 400 {
+			t.Log("Response:", resp)
+			t.Fatalf("Expected status code 400, got %d", responseCode)
+		}
+
+		// Verify the error message mentions non-empty database
+		if message, ok := resp["message"].(string); ok {
+			if !strings.Contains(message, "not empty") {
+				t.Errorf("Expected error message to mention 'not empty', got: %s", message)
+			}
+		} else {
+			t.Error("Expected error message in response")
 		}
 	})
 }


### PR DESCRIPTION
Add the command to restore a database from a restore point. The target database/branch should be empty to prevent data loss or corruption.


```shell
litebase database restore <source-database/branch> <target-database/branch> --timestamp <timestamp>
```