### PR TITLE
Refactor error handling for invalid credentials

### DIFF
--- a/pkg/http/errors.go
+++ b/pkg/http/errors.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 )
 
-var ErrInvalidAccessKey = errors.New("a valid access key is required to make this request")
-var ErrInvalidAccessKeyResponse = BadRequestResponse(ErrInvalidAccessKey)
+var ErrInvalidCredential = errors.New("a valid credential is required to make this request")
+var ErrInvalidCredentialResponse = BadRequestResponse(ErrInvalidCredential)
 var ErrValidDatabaseIdRequired = errors.New("a valid database ID is required")
 var ErrValidDatabaseIdRequiredResponse = BadRequestResponse(ErrValidDatabaseIdRequired)
 var ErrValidDatabaseNameRequired = errors.New("a valid database name is required")

--- a/pkg/http/query_controller.go
+++ b/pkg/http/query_controller.go
@@ -39,13 +39,7 @@ func QueryControllerStore(ctx context.Context, request *Request) Response {
 	credential := request.Credential()
 
 	if !credential.Valid() {
-		return ErrInvalidAccessKeyResponse
-	}
-
-	accessKey := credential.AccessKey()
-
-	if accessKey == nil {
-		return ErrInvalidAccessKeyResponse
+		return ErrInvalidCredentialResponse
 	}
 
 	// Authorize the request
@@ -121,7 +115,7 @@ func QueryControllerStore(ctx context.Context, request *Request) Response {
 			}
 
 			if transaction.Credential != nil && credential.CredentialID != transaction.Credential.CredentialID {
-				return ErrInvalidAccessKeyResponse
+				return ErrInvalidCredentialResponse
 			}
 
 			err = transaction.ResolveQuery(requestQuery, response)

--- a/pkg/http/query_stream_controller.go
+++ b/pkg/http/query_stream_controller.go
@@ -48,13 +48,13 @@ func QueryStreamControllerStore(ctx context.Context, request *Request) Response 
 	credential := request.Credential()
 
 	if !credential.Valid() {
-		return ErrInvalidAccessKeyResponse
+		return ErrInvalidCredentialResponse
 	}
 
 	accessKey := credential.AccessKey()
 
 	if accessKey.AccessKeyID == "" {
-		return ErrInvalidAccessKeyResponse
+		return ErrInvalidCredentialResponse
 	}
 
 	// Authorize the request


### PR DESCRIPTION
Replaces references to 'access key' errors with 'credential' errors in HTTP controllers and error definitions for improved clarity and consistency in authentication error handling.