### PR TITLE
Token updates

### DIFF
--- a/pkg/auth/credential.go
+++ b/pkg/auth/credential.go
@@ -79,8 +79,8 @@ func CaptureCredential(auth *Auth, authorizationHeader string) *Credential {
 	}
 
 	if scheme == "Bearer" {
-		//tokenID = lbtk_ + 32 characters
-		tokenIDLength := len("lbtk_") + 32
+		//tokenID = lbtk_ + 16 characters
+		tokenIDLength := len("lbtk_") + 16
 		tokenID := credentialValue[0:tokenIDLength]
 		tokenSecret := strings.TrimSpace(credentialValue[tokenIDLength:])
 

--- a/pkg/auth/map_secrets_store.go
+++ b/pkg/auth/map_secrets_store.go
@@ -39,7 +39,7 @@ func (store *MapSecretsStore) Forget(key string) {
 	delete(store.data, key)
 }
 
-func (store *MapSecretsStore) Get(key string, cacheItemType interface{}) interface{} {
+func (store *MapSecretsStore) Get(key string, cacheItemType any) any {
 	store.mutex.RLock()
 	secret, ok := store.data[key]
 	store.mutex.RUnlock()
@@ -60,7 +60,7 @@ func (store *MapSecretsStore) Get(key string, cacheItemType interface{}) interfa
 	return cacheItemType
 }
 
-func (store *MapSecretsStore) Put(key string, value interface{}, seconds time.Duration) bool {
+func (store *MapSecretsStore) Put(key string, value any, seconds time.Duration) bool {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 

--- a/pkg/auth/secrets_store.go
+++ b/pkg/auth/secrets_store.go
@@ -5,6 +5,6 @@ import "time"
 type SecretsStore interface {
 	Flush() error
 	Forget(key string)
-	Get(key string, cacheItemType interface{}) interface{}
+	Get(key string, cacheItemType any) any
 	Put(key string, value any, seconds time.Duration) bool
 }

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -1,22 +1,23 @@
 package auth
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"time"
-
-	"golang.org/x/crypto/bcrypt"
 )
 
 type Token struct {
-	ID          int64       `json:"-"`
-	TokenID     string      `json:"-"`
-	TokenHash   string      `json:"-"`
-	TokenSecret string      `json:"-"`
-	Statements  []Statement `json:"-"`
-	Description string      `json:"-"`
-	CreatedAt   time.Time   `json:"-"`
-	UpdatedAt   time.Time   `json:"-"`
+	ID          int64       `json:"id"`
+	TokenID     string      `json:"token_id"`
+	TokenHash   string      `json:"token_hash"`
+	TokenSecret string      `json:"token_secret,omitempty"`
+	Statements  []Statement `json:"statements"`
+	Description string      `json:"description"`
+	CreatedAt   time.Time   `json:"created_at"`
+	UpdatedAt   time.Time   `json:"updated_at"`
 
 	TokenManager *TokenManager `json:"-"`
 }
@@ -54,12 +55,11 @@ func NewToken(
 
 // Authenticate the token using the provided secret.
 func (t *Token) Authenticate(secret string) bool {
-	// Use bcrypt to compare the token hash
-	if bcrypt.CompareHashAndPassword([]byte(t.Hash()), []byte(secret)) != nil {
-		return false
-	}
+	// Use sha256 to hash the provided secret and compare with stored hash
+	hashedSecret := sha256.Sum256([]byte(secret))
+	hashedSecretHex := hex.EncodeToString(hashedSecret[:])
 
-	return true
+	return subtle.ConstantTimeCompare([]byte(t.TokenHash), []byte(hashedSecretHex)) == 1
 }
 
 // Delete a token.

--- a/pkg/auth/token_manager.go
+++ b/pkg/auth/token_manager.go
@@ -2,11 +2,11 @@ package auth
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"sync"
 	"time"
-
-	"golang.org/x/crypto/bcrypt"
 )
 
 type TokenManager struct {
@@ -86,14 +86,11 @@ func (tm *TokenManager) Create(description string, statements []Statement) (*Tok
 
 	tokenSecret := tm.GenerateTokenSecret()
 
-	// Bcrypt the secret
-	tokenHash, err := bcrypt.GenerateFromPassword([]byte(tokenSecret), bcrypt.DefaultCost)
+	// Hash with SHA256
+	tokenHashBytes := sha256.Sum256([]byte(tokenSecret))
+	tokenHash := hex.EncodeToString(tokenHashBytes[:])
 
-	if err != nil {
-		return nil, err
-	}
-
-	token := NewToken(tm, tokenID, tokenSecret, string(tokenHash), description, statements)
+	token := NewToken(tm, tokenID, tokenSecret, tokenHash, description, statements)
 
 	if err := tm.tokenStorage.Store(token); err != nil {
 		return nil, err
@@ -106,7 +103,7 @@ func (tm *TokenManager) Create(description string, statements []Statement) (*Tok
 func (tm *TokenManager) GenerateTokenSecret() string {
 	dictionary := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
-	result := make([]byte, 32)
+	result := make([]byte, 48)
 	for i := range result {
 		randomBytes := make([]byte, 1)
 
@@ -137,7 +134,7 @@ func (tm *TokenManager) GenerateTokenID() (string, error) {
 
 	// Generate a random token ID, a-zA-Z1-9
 	for {
-		result := make([]byte, 32)
+		result := make([]byte, 16)
 
 		for i := range result {
 			randomBytes := make([]byte, 1)

--- a/pkg/cli/cmd/token_create.go
+++ b/pkg/cli/cmd/token_create.go
@@ -157,6 +157,10 @@ func NewTokenCreateCmd(config *config.CLIConfiguration) *cobra.Command {
 
 			rows := []components.CardRow{
 				{
+					Key:   "Token ID",
+					Value: res["data"].(map[string]any)["token_id"].(string),
+				},
+				{
 					Key:   "Token",
 					Value: res["data"].(map[string]any)["token"].(string),
 				},

--- a/pkg/http/request.go
+++ b/pkg/http/request.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -152,7 +151,6 @@ func (r *Request) Authorize(resources []string, actions []auth.Privilege) error 
 			return fmt.Errorf("user is not authorized to perform this request")
 		}
 	case auth.CredentialTypeToken:
-		log.Println("Authorizing request with token")
 		token := r.Credential().Token()
 
 		if token == nil {


### PR DESCRIPTION
Updating the authentication and token management logic to improve security and simplify type usage. The main changes include switching token hashing from bcrypt to SHA256 (bcrypt is not the right choice for low latency requests), updating token ID and secret lengths, and standardizing interface types to use `any`. Additionally, the CLI now displays the token ID after creation.