### PR TITLE
Remove redundant access key validation

### DIFF
--- a/pkg/http/query_stream_controller.go
+++ b/pkg/http/query_stream_controller.go
@@ -51,12 +51,6 @@ func QueryStreamControllerStore(ctx context.Context, request *Request) Response 
 		return ErrInvalidCredentialResponse
 	}
 
-	accessKey := credential.AccessKey()
-
-	if accessKey.AccessKeyID == "" {
-		return ErrInvalidCredentialResponse
-	}
-
 	// Authorize the request
 	err := request.Authorize(
 		[]string{fmt.Sprintf("database:%s:branch:%s", databaseKey.DatabaseID, databaseKey.DatabaseBranchID)},


### PR DESCRIPTION
Eliminates unnecessary check for empty AccessKeyID in QueryStreamControllerStore, as credential validation is already performed earlier in the function.