### PR TITLE
Add enum support for 'oneof' validation in OpenAPI generator

### DIFF
--- a/api/generated_openapi.json
+++ b/api/generated_openapi.json
@@ -4213,7 +4213,28 @@
         ]
       },
       "StatementParameter": {
-        "type": "object"
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "TEXT",
+              "INTEGER",
+              "FLOAT",
+              "BLOB",
+              "NULL"
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/any"
+          }
+        },
+        "required": [
+          "type"
+        ]
       },
       "SuccessResponse": {
         "type": "object",
@@ -4259,6 +4280,9 @@
             "example": "error"
           }
         }
+      },
+      "any": {
+        "type": "object"
       }
     },
     "securitySchemes": {

--- a/pkg/openapi/generator.go
+++ b/pkg/openapi/generator.go
@@ -2703,6 +2703,7 @@ func (g *Generator) findTypeDefinition(typeName string) *TypeInfo {
 			"http":     "pkg/http",
 			"config":   "pkg/config",
 			"database": "pkg/database",
+			"sqlite3":  "pkg/sqlite3",
 		}
 
 		if packagePath, exists := packagePaths[packageName]; exists {
@@ -3028,6 +3029,16 @@ func (g *Generator) applyValidationToSchema(fieldInfo *FieldInfo, schema *Schema
 		case "max":
 			if maxVal, err := strconv.Atoi(value); err == nil {
 				_ = maxVal // Use the value as needed
+			}
+		case "oneof":
+			// Handle oneof validation - convert to enum
+			// The value will be like "TEXT INTEGER FLOAT BLOB NULL"
+			enumValues := strings.Fields(value)
+			if len(enumValues) > 0 {
+				schema.Enum = make([]any, len(enumValues))
+				for i, v := range enumValues {
+					schema.Enum[i] = v
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Updated the OpenAPI schema for StatementParameter to include name, type, and value properties, with type supporting an enum. Modified generator.go to handle 'oneof' validation by converting it to an enum in the schema. Also added sqlite3 to package path mapping.