### PR TITLE
Database Error Logs

### DIFF
--- a/api/generated_open_api.json
+++ b/api/generated_open_api.json
@@ -1651,6 +1651,130 @@
         }
       ]
     },
+    "/v1/databases/{databaseName}/branches/{branchName}/errors": {
+      "get": {
+        "tags": [
+          "ErrorLog"
+        ],
+        "summary": "List all error logs",
+        "description": "List error logs for a specific database and branch",
+        "operationId": "listErrorLogs",
+        "parameters": [
+          {
+            "name": "end",
+            "in": "query",
+            "description": "The end timestamp for the error logs to retrieve (in seconds since epoch).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "The start timestamp for the error logs to retrieve (in seconds since epoch).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "description": "Return value from .ErrorLogIndexResponse()"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Response message",
+                      "example": "Successfully retrieved error logs."
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Response status",
+                      "example": "success"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "message",
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "AccessKeyAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "TokenAuth": []
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "name": "databaseName",
+          "in": "path",
+          "description": "The databaseName parameter",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "example": "example_value"
+          }
+        },
+        {
+          "name": "branchName",
+          "in": "path",
+          "description": "The branchName parameter",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "example": "example_value"
+          }
+        }
+      ]
+    },
     "/v1/databases/{databaseName}/branches/{branchName}/export": {
       "post": {
         "tags": [
@@ -5934,6 +6058,10 @@
     {
       "name": "DatabaseSnapshot",
       "description": "Database snapshot operations"
+    },
+    {
+      "name": "ErrorLog",
+      "description": "Error performance and usage metrics"
     },
     {
       "name": "Import",

--- a/api/generated_open_api_test_cases.json
+++ b/api/generated_open_api_test_cases.json
@@ -316,7 +316,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_2b44d9f303d503e0"
+                  "name": "test_db_d34e334058e1e477"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -341,7 +341,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_5d71a2bbce0a44f5"
+                  "name": "test_db_6de8ca3a4075af5f"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -392,7 +392,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_91f43011c154aa3a"
+                  "name": "test_db_452a9163f56c7606"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -430,7 +430,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_df30272d1e5b0291"
+                  "name": "test_db_57cadb8548b2d329"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -472,7 +472,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_4cd9b4ecf5ab385f"
+                  "name": "test_db_336762e5bbb9ce99"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -492,7 +492,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473579000",
+                      "id": "query-923088000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -565,7 +565,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_95c4b167916bfeb2"
+                  "name": "test_db_b516b763f82b7e96"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -585,7 +585,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473633000",
+                      "id": "query-923119000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -688,7 +688,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_04133f1f3690dc10"
+                  "name": "test_db_237b0e47aba32d1e"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -708,7 +708,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473628000",
+                      "id": "query-923116000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -796,7 +796,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_2b4abb2bdac8a12a"
+                  "name": "test_db_865974b194aa41db"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -816,7 +816,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473571000",
+                      "id": "query-923086000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -893,7 +893,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_752b42f71edc9a30"
+                  "name": "test_db_62ac732c6b2ff3c5"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -913,7 +913,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473530000",
+                      "id": "query-923083000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -970,7 +970,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_c342772c7acac777"
+                  "name": "test_db_7bf6a4278da2c952"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -990,7 +990,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473619000",
+                      "id": "query-922990000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -1075,7 +1075,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_7817337f49127968"
+                  "name": "test_db_18b7800e89e99559"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1095,7 +1095,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473613000",
+                      "id": "query-922988000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -1145,7 +1145,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_2ba8fdc0aefdfe2a"
+                  "name": "test_db_a1cf95c5ee4f003e"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1165,7 +1165,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473522000",
+                      "id": "query-923080000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -1221,7 +1221,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_8f7384e0d7fd487b"
+                  "name": "test_db_faf7bedc14baa75d"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1260,7 +1260,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_0c058293d8d4ed02"
+                  "name": "test_db_59783c01c87f965c"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1318,7 +1318,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_cf8a6c10e5553bb5"
+                  "name": "test_db_3e95c7aecad61dcc"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1338,7 +1338,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473640000",
+                      "id": "query-922998000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test export data');"
                     }
@@ -1392,7 +1392,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_87f2e3e43e8c90c5"
+                  "name": "test_db_8795a0b4b2dda4e2"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1412,7 +1412,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473648000",
+                      "id": "query-923058000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -1510,7 +1510,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_41f3c776dc7f2b26"
+                  "name": "test_db_a354bf3704c4df7b"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1530,7 +1530,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473490000",
+                      "id": "query-923122000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test export data');"
                     }
@@ -1618,7 +1618,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_471aebb910348cbd"
+                  "name": "test_db_75b54de1a50c3b77"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1638,7 +1638,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473653000",
+                      "id": "query-923028000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -1687,7 +1687,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_a538df3b4201f0c8"
+                  "name": "test_db_478483d4ee3954a3"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1736,7 +1736,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_05eb092043c8526e"
+                  "name": "test_db_cb8bd8f0588b830e"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1756,7 +1756,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473694000",
+                      "id": "query-923124000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -1827,7 +1827,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_f4bbc337dc1714b1"
+                  "name": "test_db_e3e678064dd95f59"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -1847,7 +1847,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473536000",
+                      "id": "query-923054000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -1891,6 +1891,76 @@
         }
       }
     },
+    "ErrorLog": {
+      "tests": {
+        "listErrorLogs": {
+          "operationId": "listErrorLogs",
+          "name": "Test listErrorLogs - List resources",
+          "description": "Verifies the ErrorLog list operation works (read-only resource)",
+          "steps": [
+            {
+              "request": {
+                "name": "Create test Database",
+                "model": "Database",
+                "operation": "createDatabase",
+                "body": {
+                  "name": "test_db_9b0b5d4ccb220f81"
+                },
+                "requestModel": "DatabaseStoreRequest"
+              },
+              "response": {
+                "statusCode": 201,
+                "captures": [
+                  "databaseName",
+                  "branchName"
+                ]
+              }
+            },
+            {
+              "request": {
+                "name": "Execute query with error to trigger error log",
+                "model": "Query",
+                "operation": "createQuery",
+                "body": {
+                  "queries": [
+                    {
+                      "id": "query-923090000",
+                      "parameters": {},
+                      "statement": "SELECT * FROM nonexistent_table;"
+                    }
+                  ]
+                },
+                "requestModel": "QueryRequest",
+                "parameters": [
+                  "databaseName",
+                  "branchName"
+                ]
+              },
+              "response": {
+                "statusCode": 200
+              }
+            },
+            {
+              "request": {
+                "name": "List ErrorLogs",
+                "model": "ErrorLog",
+                "operation": "listErrorLogs",
+                "parameters": [
+                  "databaseName",
+                  "branchName"
+                ]
+              },
+              "response": {
+                "statusCode": 200,
+                "content": {
+                  "data": []
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
     "Import": {
       "tests": {
         "createImport": {
@@ -1905,7 +1975,7 @@
                 "operation": "createImport",
                 "body": {
                   "chunkCount": 1,
-                  "databaseName": "test_db_622cbb4f9f883f6b"
+                  "databaseName": "test_db_d006a9a6a39baddd"
                 },
                 "requestModel": "ImportStoreRequest"
               },
@@ -1931,7 +2001,7 @@
                 "operation": "createImport",
                 "body": {
                   "chunkCount": 1,
-                  "databaseName": "test_db_049c947e9e99d0e5"
+                  "databaseName": "test_db_7cb6c35f483fd030"
                 },
                 "requestModel": "ImportStoreRequest"
               },
@@ -1983,7 +2053,7 @@
                 "operation": "createImport",
                 "body": {
                   "chunkCount": 1,
-                  "databaseName": "test_db_74480d454f3a8265"
+                  "databaseName": "test_db_192c583d702fd2b9"
                 },
                 "requestModel": "ImportStoreRequest"
               },
@@ -2022,7 +2092,7 @@
                 "operation": "createImport",
                 "body": {
                   "chunkCount": 1,
-                  "databaseName": "test_db_3f44a42009fb5d5f"
+                  "databaseName": "test_db_9cd9e598e521981b"
                 },
                 "requestModel": "ImportStoreRequest"
               },
@@ -2041,7 +2111,7 @@
                 "operation": "updateImport",
                 "body": {
                   "chunkCount": 1,
-                  "databaseName": "test_db_244c2ace016882e9"
+                  "databaseName": "test_db_5a4c2e9ad00f1aa0"
                 },
                 "requestModel": "ImportUpdateRequest",
                 "parameters": [
@@ -2070,7 +2140,7 @@
                 "operation": "createImport",
                 "body": {
                   "chunkCount": 1,
-                  "databaseName": "test_db_2eb3ba2cb983b687"
+                  "databaseName": "test_db_2eff57146e3005e0"
                 },
                 "requestModel": "ImportStoreRequest"
               },
@@ -2168,7 +2238,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_ce5835da35b4f865"
+                  "name": "test_db_cab783723647f5b4"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -2188,7 +2258,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473584000",
+                      "id": "query-923005000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -2240,7 +2310,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473587000",
+                      "id": "query-923006000",
                       "parameters": {},
                       "statement": "SELECT 1"
                     }
@@ -2276,7 +2346,7 @@
                 "model": "Database",
                 "operation": "createDatabase",
                 "body": {
-                  "name": "test_db_00f6b6813f93b9f3"
+                  "name": "test_db_30b0ba9a541ebc43"
                 },
                 "requestModel": "DatabaseStoreRequest"
               },
@@ -2296,7 +2366,7 @@
                 "body": {
                   "queries": [
                     {
-                      "id": "query-473496000",
+                      "id": "query-923001000",
                       "parameters": {},
                       "statement": "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');"
                     }
@@ -2609,7 +2679,7 @@
                       "resource": "*"
                     }
                   ],
-                  "username": "test_user_sdk_473603000"
+                  "username": "test_user_sdk_923073000"
                 },
                 "requestModel": "UserStoreRequest"
               },
@@ -2644,7 +2714,7 @@
                       "resource": "*"
                     }
                   ],
-                  "username": "test_user_sdk_473460000"
+                  "username": "test_user_sdk_923105000"
                 },
                 "requestModel": "UserStoreRequest"
               },
@@ -2705,7 +2775,7 @@
                       "resource": "*"
                     }
                   ],
-                  "username": "test_user_sdk_473451000"
+                  "username": "test_user_sdk_923113000"
                 },
                 "requestModel": "UserStoreRequest"
               },
@@ -2753,7 +2823,7 @@
                       "resource": "*"
                     }
                   ],
-                  "username": "test_user_sdk_473597000"
+                  "username": "test_user_sdk_923069000"
                 },
                 "requestModel": "UserStoreRequest"
               },
@@ -2801,7 +2871,7 @@
                       "resource": "*"
                     }
                   ],
-                  "username": "test_user_sdk_473470000"
+                  "username": "test_user_sdk_923109000"
                 },
                 "requestModel": "UserStoreRequest"
               },

--- a/cmd/generate_open_api_test/main.go
+++ b/cmd/generate_open_api_test/main.go
@@ -473,6 +473,7 @@ func getPluralResourceName(resourceType string) string {
 		"DatabaseSnapshot": "DatabaseSnapshots",
 		"ClusterStatus":    "ClusterStatuses",
 		"QueryLog":         "QueryLogs",
+		"ErrorLog":         "ErrorLogs",
 		"AccessKey":        "AccessKeys",
 		"Database":         "Databases",
 		"Token":            "Tokens",
@@ -498,6 +499,7 @@ func getListOperationID(resourceType string) string {
 		"Token":            "listTokens",
 		"User":             "listUsers",
 		"QueryLog":         "listQueryLogs",
+		"ErrorLog":         "listErrorLogs",
 		"ClusterStatus":    "listClusterStatuses",
 		"Node":             "listNodes",
 		"Cluster":          "listClusters",
@@ -584,6 +586,31 @@ func generateListTestCase(operationID, resourceType string, details map[string]a
 		steps = append(steps, generateDatabaseSnapshotPrerequisites()...)
 	} else if resourceType == "QueryLog" {
 		steps = append(steps, generateQueryLogPrerequisites()...)
+
+		steps = append(steps, TestStep{
+			Request: &Request{
+				Name:       fmt.Sprintf("List %s", getPluralResourceName(resourceType)),
+				Model:      resourceType,
+				Operation:  operationID,
+				Body:       map[string]any{},
+				Parameters: extractPathParameters(details),
+			},
+			Response: &Response{
+				StatusCode: 200,
+				Content: map[string]any{
+					"data": []any{},
+				},
+			},
+		})
+
+		return TestCase{
+			OperationID: operationID,
+			Name:        fmt.Sprintf("Test %s - List resources", operationID),
+			Description: fmt.Sprintf("Verifies the %s list operation works (read-only resource)", resourceType),
+			Steps:       steps,
+		}
+	} else if resourceType == "ErrorLog" {
+		steps = append(steps, generateErrorLogPrerequisites()...)
 
 		steps = append(steps, TestStep{
 			Request: &Request{
@@ -1250,6 +1277,52 @@ func generateQueryLogPrerequisites() []TestStep {
 					map[string]any{
 						"id":         fmt.Sprintf("query-%d", time.Now().UTC().Nanosecond()),
 						"statement":  "CREATE TABLE test_table (id INTEGER PRIMARY KEY, value TEXT); INSERT INTO test_table (value) VALUES ('test');",
+						"parameters": map[string]any{},
+					},
+				},
+			},
+			Parameters: []string{"databaseName", "branchName"},
+		},
+		Response: &Response{
+			StatusCode: 200,
+			Content:    map[string]any{},
+		},
+	})
+
+	return steps
+}
+
+func generateErrorLogPrerequisites() []TestStep {
+	steps := []TestStep{}
+
+	// Step 1: Create database
+	steps = append(steps, TestStep{
+		Request: &Request{
+			Name:      "Create test Database",
+			Model:     "Database",
+			Operation: "createDatabase",
+			Body: map[string]any{
+				"name": generateRandomDatabaseName(),
+			},
+		},
+		Response: &Response{
+			StatusCode: 201,
+			Content:    map[string]any{},
+			Captures:   []string{"databaseName", "branchName"},
+		},
+	})
+
+	// Step 2: Execute query that will cause an error to trigger error log
+	steps = append(steps, TestStep{
+		Request: &Request{
+			Name:      "Execute query with error to trigger error log",
+			Model:     "Query",
+			Operation: "createQuery",
+			Body: map[string]any{
+				"queries": []any{
+					map[string]any{
+						"id":         fmt.Sprintf("query-%d", time.Now().UTC().Nanosecond()),
+						"statement":  "SELECT * FROM nonexistent_table;",
 						"parameters": map[string]any{},
 					},
 				},

--- a/pkg/cli/cmd/database.go
+++ b/pkg/cli/cmd/database.go
@@ -25,6 +25,7 @@ func NewDatabaseCmd(config *config.CLIConfiguration) *cobra.Command {
 	cmd.AddCommand(NewDatabaseUpdateCmd(config))
 	cmd.AddCommand(NewDatabaseQueryCmd(config))
 	cmd.AddCommand(NewDatabaseQueryLogCmd(config))
+	cmd.AddCommand(NewDatabaseErrorLogCmd(config))
 
 	return cmd
 }

--- a/pkg/cli/cmd/database_error_logs.go
+++ b/pkg/cli/cmd/database_error_logs.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/litebase/litebase/pkg/cli/api"
+	"github.com/litebase/litebase/pkg/cli/components"
+	"github.com/litebase/litebase/pkg/cli/config"
+	"github.com/spf13/cobra"
+)
+
+func NewDatabaseErrorLogListCmd(config *config.CLIConfiguration) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list <database/branch>",
+		Args:  cobra.ExactArgs(1),
+		Short: "List database error logs",
+		Long: `List database error logs for a specific time range.
+
+Error logs capture SQL execution failures including the statement,
+error message, credential used, and execution latency.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			databaseName, branchName, err := splitDatabasePath(args[0])
+
+			if err != nil {
+				return fmt.Errorf("invalid database path: %w", err)
+			}
+
+			startStr, err := cmd.Flags().GetString("start")
+
+			if err != nil {
+				return fmt.Errorf("failed to get start time: %w", err)
+			}
+
+			endStr, err := cmd.Flags().GetString("end")
+
+			if err != nil {
+				return fmt.Errorf("failed to get end time: %w", err)
+			}
+
+			// Default to last hour if no time range specified
+			if startStr == "" || endStr == "" {
+				now := time.Now()
+
+				if endStr == "" {
+					endStr = strconv.FormatInt(now.Unix(), 10)
+				}
+
+				if startStr == "" {
+					startStr = strconv.FormatInt(now.Add(-1*time.Hour).Unix(), 10)
+				}
+			}
+
+			start, err := strconv.ParseUint(startStr, 10, 64)
+
+			if err != nil {
+				return fmt.Errorf("invalid start timestamp: %w", err)
+			}
+
+			end, err := strconv.ParseUint(endStr, 10, 64)
+
+			if err != nil {
+				return fmt.Errorf("invalid end timestamp: %w", err)
+			}
+
+			// Build query parameters
+			queryParams := fmt.Sprintf("?start=%d&end=%d", start, end)
+
+			data, err := api.Get(
+				config,
+				fmt.Sprintf("/v1/databases/%s/branches/%s/errors%s", databaseName, branchName, queryParams),
+			)
+
+			if err != nil {
+				return err
+			}
+
+			if data["data"] == nil {
+				_, err = lipgloss.Fprint(
+					cmd.OutOrStdout(),
+					components.Container(
+						components.InfoAlert("No error entries found for the specified time range."),
+					),
+				)
+
+				return err
+			}
+
+			errorEntries, ok := data["data"].([]any)
+
+			if !ok {
+				return fmt.Errorf("invalid response format: data is not an array")
+			}
+
+			// Build table headers
+			headers := []string{
+				"Timestamp", "Credential ID", "Error", "Statement", "Latency (ms)",
+			}
+
+			var rows [][]string
+
+			for _, entryInterface := range errorEntries {
+				entry, ok := entryInterface.(map[string]any)
+
+				if !ok {
+					continue
+				}
+
+				var row []string
+
+				// Timestamp
+				if timestamp, ok := entry["Timestamp"].(float64); ok {
+					t := time.Unix(int64(timestamp), 0)
+					row = append(row, t.Format("2006-01-02 15:04:05"))
+				} else {
+					row = append(row, fmt.Sprintf("%v", entry["Timestamp"]))
+				}
+
+				// Credential ID
+				if credID, ok := entry["CredentialID"].(string); ok {
+					if len(credID) > 12 {
+						row = append(row, credID[:12]+"...")
+					} else {
+						row = append(row, credID)
+					}
+				} else {
+					row = append(row, fmt.Sprintf("%v", entry["CredentialID"]))
+				}
+
+				// Error message
+				if errMsg, ok := entry["Error"].(string); ok {
+					// Truncate long error messages
+					if len(errMsg) > 50 {
+						row = append(row, errMsg[:50]+"...")
+					} else {
+						row = append(row, errMsg)
+					}
+				} else {
+					row = append(row, fmt.Sprintf("%v", entry["Error"]))
+				}
+
+				// Statement
+				if stmt, ok := entry["Statement"].(string); ok {
+					// Truncate long statements
+					if len(stmt) > 40 {
+						row = append(row, stmt[:40]+"...")
+					} else {
+						row = append(row, stmt)
+					}
+				} else {
+					row = append(row, fmt.Sprintf("%v", entry["Statement"]))
+				}
+
+				// Latency
+				if latency, ok := entry["Latency"].(float64); ok {
+					row = append(row, fmt.Sprintf("%.2f", latency))
+				} else {
+					row = append(row, fmt.Sprintf("%v", entry["Latency"]))
+				}
+
+				rows = append(rows, row)
+			}
+
+			_, err = lipgloss.Fprint(
+				cmd.OutOrStdout(),
+				components.Container(
+					components.NewTable(headers, rows).
+						Render(config.GetInteractive()),
+				),
+			)
+
+			return err
+		},
+	}
+
+	// Add flags for time range
+	cmd.Flags().String("start", "", "Start timestamp (Unix seconds). Defaults to 1 hour ago")
+	cmd.Flags().String("end", "", "End timestamp (Unix seconds). Defaults to now")
+
+	return cmd
+}
+
+func NewDatabaseErrorLogCmd(config *config.CLIConfiguration) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "error-logs",
+		Short: "View database error logs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := cmd.Help()
+
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	cmd.AddCommand(NewDatabaseErrorLogListCmd(config))
+
+	return cmd
+}

--- a/pkg/cli/cmd/database_error_logs_test.go
+++ b/pkg/cli/cmd/database_error_logs_test.go
@@ -1,0 +1,247 @@
+package cmd_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/litebase/litebase/internal/test"
+	"github.com/litebase/litebase/pkg/auth"
+	"github.com/litebase/litebase/pkg/database"
+	"github.com/litebase/litebase/pkg/sqlite3"
+)
+
+func TestDatabaseErrorLogListSuccess(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		testDB := test.MockDatabase(server.App)
+
+		db, err := server.App.DatabaseManager.ConnectionManager().Get(testDB.DatabaseID, testDB.DatabaseBranchID)
+
+		if err != nil {
+			t.Fatalf("failed to get database connection: %v", err)
+		}
+
+		defer server.App.DatabaseManager.ConnectionManager().Release(db)
+
+		// Create table
+		_, err = db.GetConnection().Exec("CREATE TABLE test_errors (id INTEGER PRIMARY KEY, value TEXT)", nil)
+
+		if err != nil {
+			t.Fatalf("failed to create table: %v", err)
+		}
+
+		// Execute multiple queries that will generate errors
+		err = db.GetConnection().Transaction(false, func(dbConn *database.DatabaseConnection) error {
+			for i := range 5 {
+				_, _ = dbConn.Exec("INSERT INTO test_errors (nonexistent_column) VALUES (?)", []sqlite3.StatementParameter{
+					{
+						Type:  sqlite3.ParameterTypeText,
+						Value: fmt.Appendf(nil, "test value %d", i),
+					},
+				})
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			t.Fatalf("Failed to execute transaction: %v", err)
+		}
+
+		// Give some time for errors to be recorded
+		time.Sleep(100 * time.Millisecond)
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		// Test with default time range (last hour)
+		err = cli.Run("database", "error-logs", "list", fmt.Sprintf("%s/%s", testDB.DatabaseName, testDB.BranchName))
+
+		if err != nil {
+			t.Logf("Error output: %s", cli.GetOutput())
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Check for expected headers
+		if cli.DoesNotSee("Timestamp") {
+			t.Error("expected output to contain 'Timestamp' header")
+		}
+
+		if cli.DoesNotSee("Credential ID") {
+			t.Error("expected output to contain 'Credential ID' header")
+		}
+
+		if cli.DoesNotSee("Error") {
+			t.Error("expected output to contain 'Error' header")
+		}
+
+		if cli.DoesNotSee("Statement") {
+			t.Error("expected output to contain 'Statement' header")
+		}
+
+		if cli.DoesNotSee("Latency") {
+			t.Error("expected output to contain 'Latency' header")
+		}
+	})
+}
+
+func TestDatabaseErrorLogListWithTimeRange(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		testDB := test.MockDatabase(server.App)
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		// Test with specific time range
+		now := time.Now()
+		start := now.Add(-1 * time.Hour)
+		end := now
+
+		err := cli.Run(
+			"database", "error-logs", "list", fmt.Sprintf("%s/%s", testDB.DatabaseName, testDB.BranchName),
+			"--start", strconv.FormatInt(start.Unix(), 10),
+			"--end", strconv.FormatInt(end.Unix(), 10),
+		)
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Should either show error entries or "No error entries found" message
+		hasErrors := cli.Sees("Timestamp")
+		hasNoErrorsMessage := cli.Sees("No error entries found")
+
+		if !hasErrors && !hasNoErrorsMessage {
+			t.Error("expected either error entries table or 'No error entries found' message")
+		}
+	})
+}
+
+func TestDatabaseErrorLogListInvalidDatabasePath(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run("database", "error-logs", "list", "invalid-path")
+
+		if err == nil {
+			t.Error("expected error when database path is invalid, got none")
+		}
+	})
+}
+
+func TestDatabaseErrorLogListInvalidTimeStamps(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		testDB := test.MockDatabase(server.App)
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		// Test with invalid start timestamp
+		err := cli.Run(
+			"database", "error-logs", "list", fmt.Sprintf("%s/%s", testDB.DatabaseName, testDB.BranchName),
+			"--start", "invalid",
+			"--end", strconv.FormatInt(time.Now().Unix(), 10),
+		)
+
+		if err == nil {
+			t.Error("expected error with invalid start timestamp, got none")
+		}
+
+		// Test with invalid end timestamp
+		err = cli.Run(
+			"database", "error-logs", "list", fmt.Sprintf("%s/%s", testDB.DatabaseName, testDB.BranchName),
+			"--start", strconv.FormatInt(time.Now().Add(-1*time.Hour).Unix(), 10),
+			"--end", "invalid",
+		)
+
+		if err == nil {
+			t.Error("expected error with invalid end timestamp, got none")
+		}
+	})
+}
+
+func TestDatabaseErrorLogListNoPermissions(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		testDB := test.MockDatabase(server.App)
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectDeny, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run("database", "error-logs", "list", fmt.Sprintf("%s/%s", testDB.DatabaseName, testDB.BranchName))
+
+		if err == nil {
+			t.Error("expected error due to lack of permissions, got none")
+		}
+	})
+}
+
+func TestDatabaseErrorLogListNonExistentDatabase(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server).
+			WithAccessKey([]auth.Statement{
+				{Effect: auth.StatementEffectAllow, Resource: "*", Actions: []auth.Privilege{"*"}},
+			})
+
+		err := cli.Run("database", "error-logs", "list", "nonexistent/main")
+
+		if err == nil {
+			t.Error("expected error for non-existent database, got none")
+		}
+	})
+}
+
+func TestDatabaseErrorLogCommandHelp(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		cli := test.NewTestCLI(t, server.App).
+			WithServer(server)
+
+		err := cli.Run("database", "error-logs", "--help")
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if cli.DoesNotSee("View database error logs") {
+			t.Error("expected help text to contain command description")
+		}
+	})
+}

--- a/pkg/database/resolver.go
+++ b/pkg/database/resolver.go
@@ -48,8 +48,24 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 			db, err = query.databaseManager.ConnectionManager().Get(query.DatabaseKey.DatabaseID, query.DatabaseKey.DatabaseBranchID)
 
 			if err != nil {
-				log.Println("Error getting database connection", err)
+				slog.Error("Error getting database connection", "error", err)
 				response.SetError(err.Error())
+
+				// Log the error
+				err := logManager.Error(logs.ErrorLogEntry{
+					Cluster:      query.cluster,
+					DatabaseHash: query.DatabaseKey.DatabaseHash,
+					DatabaseID:   query.DatabaseKey.DatabaseID,
+					BranchID:     query.DatabaseKey.DatabaseBranchID,
+					CredentialID: query.Credential.CredentialID,
+					Statement:    query.Input.Statement,
+					Error:        err.Error(),
+					Latency:      float64(time.Since(start)) / float64(time.Millisecond),
+				})
+
+				if err != nil {
+					slog.Error("Error logging error", "error", err)
+				}
 
 				return response, err
 			}
@@ -91,6 +107,22 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 			if query.IsVacuum() {
 				response.SetError(errors.New("VACUUM is not supported from this context").Error())
 
+				// Log the error
+				err := logManager.Error(logs.ErrorLogEntry{
+					Cluster:      query.cluster,
+					DatabaseHash: query.DatabaseKey.DatabaseHash,
+					DatabaseID:   query.DatabaseKey.DatabaseID,
+					BranchID:     query.DatabaseKey.DatabaseBranchID,
+					CredentialID: query.Credential.CredentialID,
+					Statement:    query.Input.Statement,
+					Error:        "VACUUM is not supported from this context",
+					Latency:      float64(time.Since(start)) / float64(time.Millisecond),
+				})
+
+				if err != nil {
+					slog.Error("Error logging error", "error", err)
+				}
+
 				return response, errors.New("VACUUM is not supported from this context")
 			} else if query.IsPragma() && IsLitebasePragma(query.Input.Statement) {
 				// Handle litebase PRAGMAs directly through Exec
@@ -98,6 +130,23 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 
 				if err != nil {
 					response.SetError(err.Error())
+
+					// Log the error
+					err := logManager.Error(logs.ErrorLogEntry{
+						Cluster:      query.cluster,
+						DatabaseHash: query.DatabaseKey.DatabaseHash,
+						DatabaseID:   query.DatabaseKey.DatabaseID,
+						BranchID:     query.DatabaseKey.DatabaseBranchID,
+						CredentialID: query.Credential.CredentialID,
+						Statement:    query.Input.Statement,
+						Error:        err.Error(),
+						Latency:      float64(time.Since(start)) / float64(time.Millisecond),
+					})
+
+					if err != nil {
+						slog.Error("Error logging error", "error", err)
+					}
+
 					return response, err
 				}
 
@@ -156,6 +205,22 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 
 		if err != nil {
 			response.SetError(err.Error())
+
+			// Log the error
+			err := logManager.Error(logs.ErrorLogEntry{
+				Cluster:      query.cluster,
+				DatabaseHash: query.DatabaseKey.DatabaseHash,
+				DatabaseID:   query.DatabaseKey.DatabaseID,
+				BranchID:     query.DatabaseKey.DatabaseBranchID,
+				CredentialID: query.Credential.CredentialID,
+				Statement:    query.Input.Statement,
+				Error:        err.Error(),
+				Latency:      float64(time.Since(start)) / float64(time.Millisecond),
+			})
+
+			if err != nil {
+				slog.Error("Error logging error", "error", err)
+			}
 
 			return response, err
 		}

--- a/pkg/database/resolver.go
+++ b/pkg/database/resolver.go
@@ -52,7 +52,7 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 				response.SetError(err.Error())
 
 				// Log the error
-				err := logManager.Error(logs.ErrorLogEntry{
+				logError := logManager.Error(logs.ErrorLogEntry{
 					Cluster:      query.cluster,
 					DatabaseHash: query.DatabaseKey.DatabaseHash,
 					DatabaseID:   query.DatabaseKey.DatabaseID,
@@ -63,8 +63,8 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 					Latency:      float64(time.Since(start)) / float64(time.Millisecond),
 				})
 
-				if err != nil {
-					slog.Error("Error logging error", "error", err)
+				if logError != nil {
+					slog.Error("Error logging error", "error", logError)
 				}
 
 				return response, err
@@ -108,7 +108,7 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 				response.SetError(errors.New("VACUUM is not supported from this context").Error())
 
 				// Log the error
-				err := logManager.Error(logs.ErrorLogEntry{
+				logError := logManager.Error(logs.ErrorLogEntry{
 					Cluster:      query.cluster,
 					DatabaseHash: query.DatabaseKey.DatabaseHash,
 					DatabaseID:   query.DatabaseKey.DatabaseID,
@@ -119,8 +119,8 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 					Latency:      float64(time.Since(start)) / float64(time.Millisecond),
 				})
 
-				if err != nil {
-					slog.Error("Error logging error", "error", err)
+				if logError != nil {
+					slog.Error("Error logging error", "error", logError)
 				}
 
 				return response, errors.New("VACUUM is not supported from this context")
@@ -132,7 +132,7 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 					response.SetError(err.Error())
 
 					// Log the error
-					err := logManager.Error(logs.ErrorLogEntry{
+					logError := logManager.Error(logs.ErrorLogEntry{
 						Cluster:      query.cluster,
 						DatabaseHash: query.DatabaseKey.DatabaseHash,
 						DatabaseID:   query.DatabaseKey.DatabaseID,
@@ -143,8 +143,8 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 						Latency:      float64(time.Since(start)) / float64(time.Millisecond),
 					})
 
-					if err != nil {
-						slog.Error("Error logging error", "error", err)
+					if logError != nil {
+						slog.Error("Error logging error", "error", logError)
 					}
 
 					return response, err
@@ -207,7 +207,7 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 			response.SetError(err.Error())
 
 			// Log the error
-			err := logManager.Error(logs.ErrorLogEntry{
+			logError := logManager.Error(logs.ErrorLogEntry{
 				Cluster:      query.cluster,
 				DatabaseHash: query.DatabaseKey.DatabaseHash,
 				DatabaseID:   query.DatabaseKey.DatabaseID,
@@ -218,8 +218,8 @@ func resolveQueryLocally(logManager *logs.LogManager, query *Query, response *Qu
 				Latency:      float64(time.Since(start)) / float64(time.Millisecond),
 			})
 
-			if err != nil {
-				slog.Error("Error logging error", "error", err)
+			if logError != nil {
+				slog.Error("Error logging error", "error", logError)
 			}
 
 			return response, err

--- a/pkg/http/error_log_controller.go
+++ b/pkg/http/error_log_controller.go
@@ -1,0 +1,104 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/litebase/litebase/internal/utils"
+	"github.com/litebase/litebase/pkg/auth"
+	"github.com/litebase/litebase/pkg/logs"
+)
+
+// Response payload for error logs
+type ErrorLogIndexResponse []*logs.ErrorEntry
+
+type ErrorLogIndexQueryParameters struct {
+	// The start timestamp for the error logs to retrieve (in seconds since epoch).
+	Start uint64 `json:"start,string"`
+
+	// The end timestamp for the error logs to retrieve (in seconds since epoch).
+	End uint64 `json:"end,string"`
+}
+
+// List error logs for a specific database and branch
+func ErrorLogControllerIndex(ctx context.Context, request *Request) Response {
+	databaseKey, errResponse := request.DatabaseKey()
+
+	if !errResponse.IsEmpty() {
+		return errResponse
+	}
+
+	// Authorize the request
+	err := request.Authorize(
+		[]string{
+			fmt.Sprintf("database:%s:branch:*", databaseKey.DatabaseID),
+			fmt.Sprintf("database:%s:branch:%s", databaseKey.DatabaseID, databaseKey.DatabaseBranchID),
+		},
+		[]auth.Privilege{auth.DatabaseBranchPrivilegeShow},
+	)
+
+	if err != nil {
+		return ForbiddenResponse(err)
+	}
+
+	// Validate and map the request query parameters
+	queryParams, err := request.QueryParams(&ErrorLogIndexQueryParameters{})
+
+	if err != nil {
+		return BadRequestResponse(errors.New("the request query parameters are invalid"))
+	}
+
+	startTimestamp := queryParams.(*ErrorLogIndexQueryParameters).Start
+
+	if startTimestamp == 0 {
+		startTimestamp = uint64(time.Now().UTC().Truncate(time.Hour).Unix())
+	}
+
+	endTimestamp := queryParams.(*ErrorLogIndexQueryParameters).End
+
+	if endTimestamp == 0 {
+		endTimestamp = uint64(time.Now().UTC().Unix())
+	}
+
+	if endTimestamp < startTimestamp {
+		return BadRequestResponse(errors.New("end timestamp must be greater than or equal to start timestamp"))
+	}
+
+	// Use request.GetErrorLog which automatically configures encryption if needed
+	errorLog, err := request.GetErrorLog(
+		databaseKey.DatabaseHash,
+		databaseKey.DatabaseID,
+		databaseKey.DatabaseBranchID,
+	)
+
+	if err != nil {
+		return ServerErrorResponse(err)
+	}
+
+	uint32StartTimestamp, err := utils.SafeUint64ToUint32(startTimestamp)
+
+	if err != nil {
+		return BadRequestResponse(errors.New("invalid start timestamp"))
+	}
+
+	uint32EndTimestamp, err := utils.SafeUint64ToUint32(endTimestamp)
+
+	if err != nil {
+		return BadRequestResponse(errors.New("invalid end timestamp"))
+	}
+
+	// Read error entries from storage
+	errorEntries, err := errorLog.Read(uint32StartTimestamp, uint32EndTimestamp)
+
+	if err != nil {
+		return ServerErrorResponse(err)
+	}
+
+	return SuccessResponse(
+		"Successfully retrieved error logs.",
+		ErrorLogIndexResponse(errorEntries),
+		200,
+	)
+}

--- a/pkg/http/error_log_controller_test.go
+++ b/pkg/http/error_log_controller_test.go
@@ -42,7 +42,11 @@ func TestErrorLogControllerSuccess(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Manually flush the error log to ensure entries are written
-		errorLog.Flush(true)
+		err := errorLog.Flush(true)
+
+		if err != nil {
+			t.Fatalf("Failed to flush error log: %v", err)
+		}
 
 		// Set up test time range
 		now := time.Now()

--- a/pkg/http/error_log_controller_test.go
+++ b/pkg/http/error_log_controller_test.go
@@ -1,0 +1,313 @@
+package http_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/litebase/litebase/internal/test"
+	"github.com/litebase/litebase/pkg/auth"
+)
+
+func TestErrorLogControllerSuccess(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		mock := test.MockDatabase(server.App)
+
+		// Get the error log and manually write some error entries
+		errorLog := server.App.LogManager.GetErrorLog(
+			server.App.Cluster,
+			mock.DatabaseKey.DatabaseHash,
+			mock.DatabaseID,
+			mock.DatabaseBranchID,
+		)
+
+		// Write some test error entries
+		for i := range 5 {
+			err := errorLog.Write(
+				mock.Credential.CredentialID,
+				fmt.Sprintf("SELECT * FROM test%d", i),
+				fmt.Sprintf("no such table: test%d", i),
+				0.01,
+			)
+
+			if err != nil {
+				t.Fatalf("Failed to write error entry: %v", err)
+			}
+		}
+
+		// Give some time for errors to be recorded
+		time.Sleep(100 * time.Millisecond)
+
+		// Manually flush the error log to ensure entries are written
+		errorLog.Flush(true)
+
+		// Set up test time range
+		now := time.Now()
+		start := now.Add(-1 * time.Hour).Unix()
+		end := now.Unix()
+
+		client := server.WithAccessKeyClient([]auth.Statement{
+			{
+				Effect:   auth.StatementEffectAllow,
+				Resource: "*",
+				Actions:  []auth.Privilege{auth.DatabaseBranchPrivilegeShow},
+			},
+		})
+
+		resp, responseCode, err := client.Send(
+			fmt.Sprintf(
+				"/v1/databases/%s/branches/%s/errors?start=%d&end=%d",
+				mock.DatabaseName,
+				mock.BranchName,
+				start,
+				end,
+			),
+			"GET",
+			nil,
+		)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if responseCode != 200 {
+			t.Fatalf("Expected response code 200, got %d. Response: %v", responseCode, resp)
+		}
+
+		// Verify response structure
+		if resp["status"] != "success" {
+			t.Errorf("Expected status 'success', got %v", resp["status"])
+		}
+
+		// Check for data section
+		data, ok := resp["data"].([]any)
+
+		if !ok {
+			t.Fatalf("Expected data to be an array, got %T", resp["data"])
+		}
+
+		// We should have 5 error entries from our manual writes
+		if len(data) != 5 {
+			t.Errorf("Expected 5 error entries, got %d", len(data))
+		}
+
+		// Verify structure of first entry
+		if len(data) > 0 {
+			entry, ok := data[0].(map[string]any)
+
+			if !ok {
+				t.Fatalf("Expected entry to be a map, got %T", data[0])
+			}
+
+			// Check for required fields
+			if _, ok := entry["Timestamp"]; !ok {
+				t.Error("Expected entry to have Timestamp field")
+			}
+
+			if _, ok := entry["CredentialID"]; !ok {
+				t.Error("Expected entry to have CredentialID field")
+			}
+
+			if _, ok := entry["Statement"]; !ok {
+				t.Error("Expected entry to have Statement field")
+			}
+
+			if _, ok := entry["Error"]; !ok {
+				t.Error("Expected entry to have Error field")
+			}
+
+			if _, ok := entry["Latency"]; !ok {
+				t.Error("Expected entry to have Latency field")
+			}
+		}
+
+		t.Logf("Retrieved %d error entries", len(data))
+	})
+}
+
+func TestErrorLogControllerInvalidParameters(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		mock := test.MockDatabase(server.App)
+
+		client := server.WithAccessKeyClient([]auth.Statement{
+			{
+				Effect:   auth.StatementEffectAllow,
+				Resource: "*",
+				Actions:  []auth.Privilege{auth.DatabaseBranchPrivilegeShow},
+			},
+		})
+
+		testCases := []struct {
+			name         string
+			queryParams  string
+			expectedCode int
+		}{
+			{
+				name:         "End before start",
+				queryParams:  "?start=2000&end=1000",
+				expectedCode: 400,
+			},
+			{
+				name:         "Invalid start timestamp",
+				queryParams:  "?start=9999999999999999999&end=2000",
+				expectedCode: 400,
+			},
+			{
+				name:         "Invalid end timestamp",
+				queryParams:  "?start=1000&end=9999999999999999999",
+				expectedCode: 400,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				resp, responseCode, err := client.Send(
+					fmt.Sprintf(
+						"/v1/databases/%s/branches/%s/errors%s",
+						mock.DatabaseName,
+						mock.BranchName,
+						tc.queryParams,
+					),
+					"GET",
+					nil,
+				)
+
+				if err != nil {
+					t.Fatalf("Expected no error, got %v", err)
+				}
+
+				if responseCode != tc.expectedCode {
+					t.Errorf("Expected response code %d, got %d. Response: %v", tc.expectedCode, responseCode, resp)
+				}
+			})
+		}
+	})
+}
+
+func TestErrorLogControllerUnauthorized(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		mock := test.MockDatabase(server.App)
+
+		// Client with no permissions
+		client := server.WithAccessKeyClient([]auth.Statement{
+			{
+				Effect:   auth.StatementEffectDeny,
+				Resource: "*",
+				Actions:  []auth.Privilege{auth.DatabaseBranchPrivilegeShow},
+			},
+		})
+
+		now := time.Now()
+		start := now.Add(-1 * time.Hour).Unix()
+		end := now.Unix()
+
+		resp, responseCode, err := client.Send(
+			fmt.Sprintf(
+				"/v1/databases/%s/branches/%s/errors?start=%d&end=%d",
+				mock.DatabaseName,
+				mock.BranchName,
+				start,
+				end,
+			),
+			"GET",
+			nil,
+		)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if responseCode != 403 {
+			t.Errorf("Expected response code 403, got %d. Response: %v", responseCode, resp)
+		}
+	})
+}
+
+func TestErrorLogControllerNonExistentDatabase(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		client := server.WithAccessKeyClient([]auth.Statement{
+			{
+				Effect:   auth.StatementEffectAllow,
+				Resource: "*",
+				Actions:  []auth.Privilege{auth.DatabaseBranchPrivilegeShow},
+			},
+		})
+
+		now := time.Now()
+		start := now.Add(-1 * time.Hour).Unix()
+		end := now.Unix()
+
+		resp, responseCode, err := client.Send(
+			fmt.Sprintf(
+				"/v1/databases/%s/branches/%s/errors?start=%d&end=%d",
+				"nonexistent",
+				"main",
+				start,
+				end,
+			),
+			"GET",
+			nil,
+		)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if responseCode != 404 {
+			t.Errorf("Expected response code 404, got %d. Response: %v", responseCode, resp)
+		}
+	})
+}
+
+func TestErrorLogControllerDefaultTimeRange(t *testing.T) {
+	test.Run(t, func() {
+		server := test.NewTestServer(t)
+		defer server.Shutdown()
+
+		mock := test.MockDatabase(server.App)
+
+		client := server.WithAccessKeyClient([]auth.Statement{
+			{
+				Effect:   auth.StatementEffectAllow,
+				Resource: "*",
+				Actions:  []auth.Privilege{auth.DatabaseBranchPrivilegeShow},
+			},
+		})
+
+		// Request without time range parameters - should use defaults
+		resp, responseCode, err := client.Send(
+			fmt.Sprintf(
+				"/v1/databases/%s/branches/%s/errors",
+				mock.DatabaseName,
+				mock.BranchName,
+			),
+			"GET",
+			nil,
+		)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if responseCode != 200 {
+			t.Fatalf("Expected response code 200, got %d. Response: %v", responseCode, resp)
+		}
+
+		// Verify response structure
+		if resp["status"] != "success" {
+			t.Errorf("Expected status 'success', got %v", resp["status"])
+		}
+	})
+}

--- a/pkg/http/public_routes.go
+++ b/pkg/http/public_routes.go
@@ -317,6 +317,12 @@ func LoadPublicRoutes(router *Router) {
 		Authentication,
 	}).Timeout(1 * time.Second)
 
+	router.Get("/v1/databases/{databaseName}/branches/{branchName}/errors",
+		ErrorLogControllerIndex,
+	).Middleware([]Middleware{
+		Authentication,
+	}).Timeout(1 * time.Second)
+
 	router.Post("/v1/databases/{databaseName}/branches/{branchName}/query",
 		QueryControllerStore,
 	).Middleware([]Middleware{

--- a/pkg/http/request.go
+++ b/pkg/http/request.go
@@ -559,6 +559,46 @@ func (request *Request) GetQueryLog(databaseHash, databaseID, branchID string) (
 	return queryLog, nil
 }
 
+// GetErrorLog returns an error log for the specified database, automatically
+// configuring encryption if the database/branch is encrypted.
+func (request *Request) GetErrorLog(databaseHash, databaseID, branchID string) (*logs.ErrorLog, error) {
+	errorLog := request.logManager.GetErrorLog(request.cluster, databaseHash, databaseID, branchID)
+
+	// Check if the database is encrypted and configure encryption if needed
+	db, err := request.databaseManager.Get(databaseID)
+
+	if err != nil {
+		return errorLog, nil // Return error log even if we can't check encryption
+	}
+
+	branch, err := db.BranchByID(branchID)
+
+	if err != nil {
+		return errorLog, nil // Return error log even if we can't check encryption
+	}
+
+	// If the branch is encrypted and error log isn't already encrypted, configure it
+	if branch.Settings != nil && branch.Settings.Encrypted && branch.Settings.DataEncryptionKeyHash != "" && !errorLog.IsEncrypted() {
+		dataKey, keyHash, err := database.MatchEncryptionKey(
+			request.cluster.Config,
+			branch.Settings.DataEncryptionKeyHash)
+
+		if err != nil {
+			slog.Error("Failed to match encryption key for error log", "error", err)
+			return errorLog, err
+		}
+
+		err = errorLog.ConfigureEncryption(dataKey, keyHash)
+
+		if err != nil {
+			slog.Error("Failed to configure error log encryption", "error", err)
+			return errorLog, err
+		}
+	}
+
+	return errorLog, nil
+}
+
 func (request *Request) Validate(
 	input any,
 	messages map[string]string,

--- a/pkg/http/routes_test.go
+++ b/pkg/http/routes_test.go
@@ -407,7 +407,7 @@ func TestPublicRoutesHaveMiddleware(t *testing.T) {
 	appHttp.LoadPublicRoutes(router)
 
 	// Count total routes defined in our test cases
-	expectedRouteCount := 46 // Update this number if you add more routes
+	expectedRouteCount := 47 // Update this number if you add more routes
 
 	totalRoutes := 0
 

--- a/pkg/logs/error_log.go
+++ b/pkg/logs/error_log.go
@@ -257,11 +257,9 @@ func (e *ErrorLog) Read(startTimestamp, endTimestamp uint32) ([]*ErrorEntry, err
 
 	var entries []*ErrorEntry
 
-	buffer := make([]byte, 1024*4) // 4KB buffer
-
 	for {
 		// Read entry from file
-		entry, err := e.readEntry(f, buffer, startTimestamp, endTimestamp)
+		entry, err := e.readEntry(f, startTimestamp, endTimestamp)
 
 		if err != nil {
 			if err.Error() == "EOF" {
@@ -280,7 +278,7 @@ func (e *ErrorLog) Read(startTimestamp, endTimestamp uint32) ([]*ErrorEntry, err
 }
 
 // readEntry reads a single error entry from the file
-func (e *ErrorLog) readEntry(f internalStorage.File, buffer []byte, startTimestamp, endTimestamp uint32) (*ErrorEntry, error) {
+func (e *ErrorLog) readEntry(f internalStorage.File, startTimestamp, endTimestamp uint32) (*ErrorEntry, error) {
 	// Read timestamp (4 bytes)
 	timestampBytes := make([]byte, 4)
 

--- a/pkg/logs/error_log.go
+++ b/pkg/logs/error_log.go
@@ -1,0 +1,576 @@
+package logs
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	internalStorage "github.com/litebase/litebase/internal/storage"
+	"github.com/litebase/litebase/internal/utils"
+	"github.com/litebase/litebase/pkg/cluster"
+	"github.com/litebase/litebase/pkg/storage"
+)
+
+var ErrorLogFlushInterval = time.Second * 5
+
+type ErrorLog struct {
+	branchId       string
+	cancel         context.CancelFunc
+	cluster        *cluster.Cluster
+	context        context.Context
+	databaseHash   string
+	databaseId     string
+	dataKey        []byte // Optional: 32-byte encryption key
+	encrypted      bool   // Whether error logs should be encrypted
+	file           internalStorage.File
+	keyHash        [32]byte // Optional: SHA256 hash of encryption key
+	lastLoggedTime time.Time
+	mutex          sync.RWMutex
+	path           string
+	queue          []*ErrorEntry
+	timestamp      int64
+	tmpFS          *storage.FileSystem
+	watching       bool
+}
+
+type ErrorLogEntry struct {
+	Cluster                                          *cluster.Cluster
+	DatabaseHash, DatabaseID, BranchID, CredentialID string
+	Statement                                        string
+	Error                                            string
+	Latency                                          float64
+}
+
+type ErrorEntry struct {
+	Timestamp    uint32
+	CredentialID string
+	Statement    string
+	Error        string
+	Latency      float64
+}
+
+// ConfigureEncryption sets the encryption parameters for the ErrorLog.
+// This must be called before any error logs are written.
+func (e *ErrorLog) ConfigureEncryption(dataKey []byte, keyHash [32]byte) error {
+	if len(dataKey) != 32 {
+		return fmt.Errorf("dataKey must be 32 bytes, got %d", len(dataKey))
+	}
+
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	e.dataKey = dataKey
+	e.keyHash = keyHash
+	e.encrypted = true
+
+	return nil
+}
+
+// IsEncrypted returns whether encryption is configured for this ErrorLog.
+func (e *ErrorLog) IsEncrypted() bool {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+
+	return e.encrypted
+}
+
+func (e *ErrorLog) Close() error {
+	// Flush before closing
+	err := e.Flush(true)
+
+	if err != nil {
+		slog.Error("Error flushing error log before close", "error", err)
+	}
+
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	e.cancel()
+
+	if e.file != nil {
+		err := e.file.Close()
+
+		if err != nil {
+			return err
+		}
+
+		e.file = nil
+	}
+
+	return nil
+}
+
+// Flush writes queued error entries to storage
+func (e *ErrorLog) Flush(force bool) error {
+	e.mutex.Lock()
+
+	if !force && len(e.queue) == 0 {
+		e.mutex.Unlock()
+		return nil
+	}
+
+	// Make a copy of the queue to minimize lock time
+	queueCopy := make([]*ErrorEntry, len(e.queue))
+	copy(queueCopy, e.queue)
+	e.queue = e.queue[:0] // Clear queue
+
+	e.mutex.Unlock()
+
+	if len(queueCopy) == 0 {
+		return nil
+	}
+
+	// Write entries to file
+	for _, entry := range queueCopy {
+		err := e.writeEntry(entry)
+
+		if err != nil {
+			slog.Error("Failed to write error entry", "error", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// GetFile returns the error log file, creating it if necessary
+func (e *ErrorLog) GetFile() (internalStorage.File, error) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	if e.file != nil {
+		return e.file, nil
+	}
+
+	logPath := fmt.Sprintf("%s-%d.log", e.path, e.timestamp)
+
+tryOpen:
+	// Use encrypted stream file if encryption is configured
+	if e.encrypted {
+		f, err := e.tmpFS.OpenFile(logPath, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0600)
+
+		if err != nil {
+			if os.IsNotExist(err) {
+				err := e.tmpFS.MkdirAll(filepath.Dir(logPath), 0750)
+
+				if err != nil {
+					return nil, err
+				}
+
+				goto tryOpen
+			}
+
+			return nil, err
+		}
+
+		encryptedFile, err := storage.NewEncryptedStreamFile(
+			f,
+			e.dataKey,
+			e.keyHash,
+			0,       // File offset (0 for new files)
+			logPath, // Path for error messages
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		e.file = encryptedFile
+
+		return e.file, nil
+	}
+
+	// Open regular file
+	f, err := e.tmpFS.OpenFile(logPath, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0600)
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			err := e.tmpFS.MkdirAll(filepath.Dir(logPath), 0750)
+
+			if err != nil {
+				return nil, err
+			}
+
+			goto tryOpen
+		}
+
+		return nil, err
+	}
+
+	e.file = f
+
+	return e.file, nil
+}
+
+// Read reads error logs from storage for a time range
+func (e *ErrorLog) Read(startTimestamp, endTimestamp uint32) ([]*ErrorEntry, error) {
+	// Get the log file path
+	logPath := fmt.Sprintf("%s-%d.log", e.path, e.timestamp)
+
+	// Check if file exists
+	if _, err := e.tmpFS.Stat(logPath); os.IsNotExist(err) {
+		return []*ErrorEntry{}, nil
+	}
+
+	var f internalStorage.File
+	var err error
+
+	// Open file with encryption if configured
+	if e.encrypted {
+		baseFile, err := e.tmpFS.Open(logPath)
+
+		if err != nil {
+			return []*ErrorEntry{}, nil
+		}
+
+		f, err = storage.OpenEncryptedStreamFile(
+			baseFile,
+			e.dataKey,
+			e.keyHash,
+			0,       // File offset
+			logPath, // Path for error messages
+		)
+
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		f, err = e.tmpFS.Open(logPath)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			slog.Error("Error closing error log file", "error", err)
+		}
+	}()
+
+	var entries []*ErrorEntry
+
+	buffer := make([]byte, 1024*4) // 4KB buffer
+
+	for {
+		// Read entry from file
+		entry, err := e.readEntry(f, buffer, startTimestamp, endTimestamp)
+
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+
+			return nil, err
+		}
+
+		if entry != nil {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries, nil
+}
+
+// readEntry reads a single error entry from the file
+func (e *ErrorLog) readEntry(f internalStorage.File, buffer []byte, startTimestamp, endTimestamp uint32) (*ErrorEntry, error) {
+	// Read timestamp (4 bytes)
+	timestampBytes := make([]byte, 4)
+
+	n, err := f.Read(timestampBytes)
+
+	if err != nil || n == 0 {
+		return nil, fmt.Errorf("EOF")
+	}
+
+	timestamp := binary.LittleEndian.Uint32(timestampBytes)
+
+	// Skip if outside range
+	if timestamp < startTimestamp || timestamp > endTimestamp {
+		// Still need to skip the rest of the entry
+		return nil, e.skipEntry(f)
+	}
+
+	// Read credential ID length (2 bytes)
+	credLenBytes := make([]byte, 2)
+
+	_, err = f.Read(credLenBytes)
+
+	if err != nil {
+		return nil, err
+	}
+
+	credLen := binary.LittleEndian.Uint16(credLenBytes)
+
+	// Read credential ID
+	credIDBytes := make([]byte, credLen)
+
+	_, err = f.Read(credIDBytes)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Read statement length (4 bytes)
+	stmtLenBytes := make([]byte, 4)
+
+	_, err = f.Read(stmtLenBytes)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stmtLen := binary.LittleEndian.Uint32(stmtLenBytes)
+
+	// Read statement - create new slice to avoid reusing buffer
+	stmtBytes := make([]byte, stmtLen)
+
+	_, err = f.Read(stmtBytes)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Read error length (4 bytes)
+	errLenBytes := make([]byte, 4)
+
+	_, err = f.Read(errLenBytes)
+
+	if err != nil {
+		return nil, err
+	}
+
+	errLen := binary.LittleEndian.Uint32(errLenBytes)
+
+	// Read error message - create new slice to avoid reusing buffer
+	errBytes := make([]byte, errLen)
+
+	_, err = f.Read(errBytes)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Read latency (8 bytes float64)
+	latencyBytes := make([]byte, 8)
+
+	_, err = f.Read(latencyBytes)
+
+	if err != nil {
+		return nil, err
+	}
+
+	latency := math.Float64frombits(binary.LittleEndian.Uint64(latencyBytes))
+
+	return &ErrorEntry{
+		Timestamp:    timestamp,
+		CredentialID: string(credIDBytes),
+		Statement:    string(stmtBytes),
+		Error:        string(errBytes),
+		Latency:      latency,
+	}, nil
+}
+
+// skipEntry skips the rest of an error entry
+func (e *ErrorLog) skipEntry(f internalStorage.File) error {
+	// Read credential ID length and skip
+	credLenBytes := make([]byte, 2)
+
+	_, err := f.Read(credLenBytes)
+
+	if err != nil {
+		return err
+	}
+
+	credLen := binary.LittleEndian.Uint16(credLenBytes)
+
+	if _, err := f.Seek(int64(credLen), 1); err != nil {
+		return err
+	}
+
+	// Read statement length and skip
+	stmtLenBytes := make([]byte, 4)
+
+	_, err = f.Read(stmtLenBytes)
+
+	if err != nil {
+		return err
+	}
+
+	stmtLen := binary.LittleEndian.Uint32(stmtLenBytes)
+
+	if _, err := f.Seek(int64(stmtLen), 1); err != nil {
+		return err
+	}
+
+	// Read error length and skip
+	errLenBytes := make([]byte, 4)
+
+	_, err = f.Read(errLenBytes)
+
+	if err != nil {
+		return err
+	}
+
+	errLen := binary.LittleEndian.Uint32(errLenBytes)
+
+	if _, err := f.Seek(int64(errLen), 1); err != nil {
+		return err
+	}
+
+	// Skip latency (8 bytes)
+	if _, err := f.Seek(8, 1); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Watch starts background flushing of queued entries
+func (e *ErrorLog) Watch() {
+	if e.watching {
+		return
+	}
+
+	e.watching = true
+
+	go func() {
+		ticker := time.NewTicker(ErrorLogFlushInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-e.context.Done():
+				return
+			case <-ticker.C:
+				if err := e.Flush(false); err != nil {
+					slog.Error("Failed to flush error log", "error", err)
+				}
+			}
+		}
+	}()
+}
+
+// Write queues an error entry for writing
+func (e *ErrorLog) Write(credentialID, statement, errorMsg string, latency float64) error {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	// Start watching if not already
+	if !e.watching {
+		e.mutex.Unlock()
+		e.Watch()
+		e.mutex.Lock()
+	}
+
+	timestamp, err := utils.SafeInt64ToUint32(time.Now().UTC().Unix())
+
+	if err != nil {
+		return err
+	}
+
+	entry := &ErrorEntry{
+		Timestamp:    timestamp,
+		CredentialID: credentialID,
+		Statement:    statement,
+		Error:        errorMsg,
+		Latency:      latency,
+	}
+
+	e.queue = append(e.queue, entry)
+	e.lastLoggedTime = time.Now().UTC()
+
+	return nil
+}
+
+// writeEntry writes a single error entry to the file
+func (e *ErrorLog) writeEntry(entry *ErrorEntry) error {
+	f, err := e.GetFile()
+
+	if err != nil {
+		return err
+	}
+
+	buffer := bytes.NewBuffer(make([]byte, 0, 1024))
+
+	// Write timestamp (4 bytes)
+	timestampBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(timestampBytes, entry.Timestamp)
+	buffer.Write(timestampBytes)
+
+	// Write credential ID length (2 bytes) and value
+	credIDBytes := []byte(entry.CredentialID)
+	credLenBytes := make([]byte, 2)
+	binary.LittleEndian.PutUint16(credLenBytes, uint16(len(credIDBytes)))
+	buffer.Write(credLenBytes)
+	buffer.Write(credIDBytes)
+
+	// Write statement length (4 bytes) and value
+	stmtBytes := []byte(entry.Statement)
+	stmtLenBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(stmtLenBytes, uint32(len(stmtBytes)))
+	buffer.Write(stmtLenBytes)
+	buffer.Write(stmtBytes)
+
+	// Write error length (4 bytes) and value
+	errBytes := []byte(entry.Error)
+	errLenBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(errLenBytes, uint32(len(errBytes)))
+	buffer.Write(errLenBytes)
+	buffer.Write(errBytes)
+
+	// Write latency (8 bytes float64)
+	latencyBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(latencyBytes, math.Float64bits(entry.Latency))
+	buffer.Write(latencyBytes)
+
+	// Write to file
+	_, err = f.Write(buffer.Bytes())
+
+	return err
+}
+
+// Bytes returns the byte representation of an ErrorEntry for storage
+func (e *ErrorEntry) Bytes() ([]byte, error) {
+	buffer := bytes.NewBuffer(make([]byte, 0, 1024))
+
+	// Write timestamp
+	timestampBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(timestampBytes, e.Timestamp)
+	buffer.Write(timestampBytes)
+
+	// Write credential ID
+	credIDBytes := []byte(e.CredentialID)
+	credLenBytes := make([]byte, 2)
+	binary.LittleEndian.PutUint16(credLenBytes, uint16(len(credIDBytes)))
+	buffer.Write(credLenBytes)
+	buffer.Write(credIDBytes)
+
+	// Write statement
+	stmtBytes := []byte(e.Statement)
+	stmtLenBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(stmtLenBytes, uint32(len(stmtBytes)))
+	buffer.Write(stmtLenBytes)
+	buffer.Write(stmtBytes)
+
+	// Write error
+	errBytes := []byte(e.Error)
+	errLenBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(errLenBytes, uint32(len(errBytes)))
+	buffer.Write(errLenBytes)
+	buffer.Write(errBytes)
+
+	// Write latency
+	latencyBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(latencyBytes, math.Float64bits(e.Latency))
+	buffer.Write(latencyBytes)
+
+	return buffer.Bytes(), nil
+}

--- a/pkg/logs/error_log_test.go
+++ b/pkg/logs/error_log_test.go
@@ -69,7 +69,11 @@ func TestErrorLog_Flush(t *testing.T) {
 			db.DatabaseBranchID,
 		)
 
-		errorLog.Flush(true)
+		err := errorLog.Flush(true)
+
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		file, err := errorLog.GetFile()
 
@@ -99,7 +103,11 @@ func TestErrorLog_Flush(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		errorLog.Flush(true)
+		err = errorLog.Flush(true)
+
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		file, err = errorLog.GetFile()
 
@@ -159,7 +167,11 @@ func TestErrorLog_Read(t *testing.T) {
 			}
 		}
 
-		errorLog.Flush(true)
+		err := errorLog.Flush(true)
+
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		endTime := time.Now().UTC().Add(time.Second)
 
@@ -272,7 +284,11 @@ func TestErrorLog_MultipleWrites(t *testing.T) {
 			}
 		}
 
-		errorLog.Flush(true)
+		err := errorLog.Flush(true)
+
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		file, err := errorLog.GetFile()
 
@@ -395,7 +411,11 @@ func TestErrorLog_WriteAndReadEncrypted(t *testing.T) {
 			}
 		}
 
-		errorLog.Flush(true)
+		err := errorLog.Flush(true)
+
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		endTime := time.Now().UTC().Add(time.Second)
 
@@ -464,7 +484,11 @@ func TestErrorLog_MultipleWritesEncrypted(t *testing.T) {
 			}
 		}
 
-		errorLog.Flush(true)
+		err := errorLog.Flush(true)
+
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		file, err := errorLog.GetFile()
 

--- a/pkg/logs/error_log_test.go
+++ b/pkg/logs/error_log_test.go
@@ -1,6 +1,7 @@
 package logs_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -311,6 +312,175 @@ func TestErrorLog_GetFile(t *testing.T) {
 
 		if file == nil {
 			t.Fatal("File is nil")
+		}
+	})
+}
+
+func TestErrorLog_EncryptionConfiguration(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockDatabase(app)
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		// Initially, encryption should not be configured
+		if errorLog.IsEncrypted() {
+			t.Fatal("Error log should not be encrypted initially")
+		}
+
+		// Configure encryption
+		dataKey := make([]byte, 32)
+
+		for i := range dataKey {
+			dataKey[i] = byte(i)
+		}
+
+		var keyHash [32]byte
+
+		for i := range keyHash {
+			keyHash[i] = byte(i + 32)
+		}
+
+		err := errorLog.ConfigureEncryption(dataKey, keyHash)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify encryption is now enabled
+		if !errorLog.IsEncrypted() {
+			t.Fatal("Error log should be encrypted after configuration")
+		}
+	})
+}
+
+func TestErrorLog_WriteAndReadEncrypted(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockEncryptedDatabase(app)
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		startTime := time.Now().UTC()
+
+		// Write encrypted error entries
+		testErrors := []struct {
+			statement string
+			error     string
+			latency   float64
+		}{
+			{"SELECT * FROM encrypted1", "no such table: encrypted1", 0.01},
+			{"INSERT INTO encrypted2 (col) VALUES (?)", "no such table: encrypted2", 0.02},
+			{"UPDATE encrypted3 SET col = ?", "no such table: encrypted3", 0.03},
+		}
+
+		for _, te := range testErrors {
+			err := errorLog.Write(
+				db.Credential.CredentialID,
+				te.statement,
+				te.error,
+				te.latency,
+			)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		errorLog.Flush(true)
+
+		endTime := time.Now().UTC().Add(time.Second)
+
+		uint32StartTime, err := utils.SafeUint64ToUint32(uint64(startTime.Unix()))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		uint32EndTime, err := utils.SafeUint64ToUint32(uint64(endTime.Unix()))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Read the encrypted errors back
+		entries, err := errorLog.Read(uint32StartTime, uint32EndTime)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(entries) != len(testErrors) {
+			t.Fatalf("Expected %d entries, got %d", len(testErrors), len(entries))
+		}
+
+		// Verify the decrypted entries match the original data
+		for i, entry := range entries {
+			if entry.Statement != testErrors[i].statement {
+				t.Errorf("Expected statement '%s', got '%s'", testErrors[i].statement, entry.Statement)
+			}
+
+			if entry.Error != testErrors[i].error {
+				t.Errorf("Expected error '%s', got '%s'", testErrors[i].error, entry.Error)
+			}
+
+			if entry.CredentialID != db.Credential.CredentialID {
+				t.Errorf("Expected credential ID '%s', got '%s'", db.Credential.CredentialID, entry.CredentialID)
+			}
+		}
+	})
+}
+
+func TestErrorLog_MultipleWritesEncrypted(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockEncryptedDatabase(app)
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		// Write multiple error entries to encrypted database
+		for i := range 10 {
+			err := errorLog.Write(
+				db.Credential.CredentialID,
+				fmt.Sprintf("SELECT * FROM encrypted_test%d", i),
+				fmt.Sprintf("no such table: encrypted_test%d", i),
+				0.01,
+			)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		errorLog.Flush(true)
+
+		file, err := errorLog.GetFile()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fileInfo, err := file.Stat()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify data was written (encrypted data should have size > 0)
+		if fileInfo.Size() == 0 {
+			t.Fatal("File size should not be 0 after writing encrypted entries")
 		}
 	})
 }

--- a/pkg/logs/error_log_test.go
+++ b/pkg/logs/error_log_test.go
@@ -1,0 +1,316 @@
+package logs_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/litebase/litebase/internal/test"
+	"github.com/litebase/litebase/internal/utils"
+	"github.com/litebase/litebase/pkg/logs"
+	"github.com/litebase/litebase/pkg/server"
+)
+
+func TestErrorLog_Close(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockDatabase(app)
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		err := errorLog.Close()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestErrorLog_Write(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockDatabase(app)
+
+		logs.ErrorLogFlushInterval = time.Millisecond * 1
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		err := errorLog.Write(
+			db.Credential.CredentialID,
+			"INSERT INTO test (invalid_column) VALUES (?)",
+			"no such column: invalid_column",
+			0.05,
+		)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestErrorLog_Flush(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockDatabase(app)
+
+		logs.ErrorLogFlushInterval = time.Millisecond * 1
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		errorLog.Flush(true)
+
+		file, err := errorLog.GetFile()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fileInfo, err := file.Stat()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Ensure file is initially empty
+		if fileInfo.Size() != 0 {
+			t.Fatal("File size should be 0 initially")
+		}
+
+		err = errorLog.Write(
+			db.Credential.CredentialID,
+			"SELECT * FROM nonexistent",
+			"no such table: nonexistent",
+			0.01,
+		)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		errorLog.Flush(true)
+
+		file, err = errorLog.GetFile()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fileInfo, err = file.Stat()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Ensure data was written to the file
+		if fileInfo.Size() == 0 {
+			t.Fatal("File size should not be 0 after writing error entry")
+		}
+	})
+}
+
+func TestErrorLog_Read(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockDatabase(app)
+
+		logs.ErrorLogFlushInterval = time.Millisecond * 1
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		startTime := time.Now().UTC().Truncate(time.Second)
+
+		// Write some test errors
+		testErrors := []struct {
+			statement string
+			error     string
+			latency   float64
+		}{
+			{"SELECT * FROM test1", "no such table: test1", 0.01},
+			{"INSERT INTO test2 (col) VALUES (?)", "no such table: test2", 0.02},
+			{"UPDATE test3 SET col = ?", "no such table: test3", 0.03},
+		}
+
+		for _, te := range testErrors {
+			err := errorLog.Write(
+				db.Credential.CredentialID,
+				te.statement,
+				te.error,
+				te.latency,
+			)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		errorLog.Flush(true)
+
+		endTime := time.Now().UTC().Add(time.Second)
+
+		uint32StartTime, err := utils.SafeUint64ToUint32(uint64(startTime.Unix()))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		uint32EndTime, err := utils.SafeUint64ToUint32(uint64(endTime.Unix()))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Read the errors back
+		entries, err := errorLog.Read(uint32StartTime, uint32EndTime)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(entries) != len(testErrors) {
+			t.Fatalf("Expected %d entries, got %d", len(testErrors), len(entries))
+		}
+
+		// Verify the entries
+		for i, entry := range entries {
+			if entry.Statement != testErrors[i].statement {
+				t.Errorf("Expected statement '%s', got '%s'", testErrors[i].statement, entry.Statement)
+			}
+
+			if entry.Error != testErrors[i].error {
+				t.Errorf("Expected error '%s', got '%s'", testErrors[i].error, entry.Error)
+			}
+
+			if entry.CredentialID != db.Credential.CredentialID {
+				t.Errorf("Expected credential ID '%s', got '%s'", db.Credential.CredentialID, entry.CredentialID)
+			}
+
+			if entry.Latency != testErrors[i].latency {
+				t.Errorf("Expected latency %f, got %f", testErrors[i].latency, entry.Latency)
+			}
+		}
+	})
+}
+
+func TestErrorLog_ReadEmptyRange(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockDatabase(app)
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		// Read from a time range in the future
+		futureTime := time.Now().UTC().Add(24 * time.Hour)
+
+		uint32Start, err := utils.SafeUint64ToUint32(uint64(futureTime.Unix()))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		uint32End, err := utils.SafeUint64ToUint32(uint64(futureTime.Add(time.Hour).Unix()))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		entries, err := errorLog.Read(uint32Start, uint32End)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(entries) != 0 {
+			t.Fatalf("Expected 0 entries, got %d", len(entries))
+		}
+	})
+}
+
+func TestErrorLog_MultipleWrites(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockDatabase(app)
+
+		logs.ErrorLogFlushInterval = time.Millisecond * 1
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		// Write multiple errors
+		for i := range 10 {
+			err := errorLog.Write(
+				db.Credential.CredentialID,
+				"SELECT * FROM test",
+				"test error",
+				float64(i)*0.01,
+			)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		errorLog.Flush(true)
+
+		file, err := errorLog.GetFile()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fileInfo, err := file.Stat()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Ensure data was written
+		if fileInfo.Size() == 0 {
+			t.Fatal("File size should not be 0 after writing multiple entries")
+		}
+	})
+}
+
+func TestErrorLog_GetFile(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockDatabase(app)
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		file, err := errorLog.GetFile()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if file == nil {
+			t.Fatal("File is nil")
+		}
+	})
+}

--- a/pkg/logs/log_manager.go
+++ b/pkg/logs/log_manager.go
@@ -19,6 +19,7 @@ var QueryLogManagerFlushThreshold = time.Minute * 1
 type LogManager struct {
 	context        context.Context
 	deletingLogs   bool
+	errorLogs      map[string]*ErrorLog
 	queryLogBuffer sync.Pool
 	queryLogs      map[string]*QueryLog
 	mutex          *sync.Mutex
@@ -26,7 +27,8 @@ type LogManager struct {
 
 func NewLogManager(context context.Context) *LogManager {
 	return &LogManager{
-		context: context,
+		context:   context,
+		errorLogs: make(map[string]*ErrorLog),
 		queryLogBuffer: sync.Pool{
 			New: func() any {
 				return bytes.NewBuffer(make([]byte, 1024))
@@ -50,6 +52,16 @@ func (lm *LogManager) Close() error {
 	}
 
 	lm.queryLogs = make(map[string]*QueryLog)
+
+	for _, log := range lm.errorLogs {
+		err := log.Close()
+
+		if err != nil {
+			return err
+		}
+	}
+
+	lm.errorLogs = make(map[string]*ErrorLog)
 
 	return nil
 }
@@ -99,6 +111,77 @@ func (lm *LogManager) GetQueryLog(cluster *cluster.Cluster, databaseHash, databa
 	}
 
 	return lm.queryLogs[databaseHash]
+}
+
+func (lm *LogManager) GetErrorLog(cluster *cluster.Cluster, databaseHash, databaseId, branchId string) *ErrorLog {
+	// Get the current time in UTC
+	t := time.Now().UTC()
+
+	// Set the timestamp to the start of the day
+	timestamp := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+
+	lm.mutex.Lock()
+	defer lm.mutex.Unlock()
+
+	// If the date has changed, close the current log file and remove to reopen.
+	if log, ok := lm.errorLogs[databaseHash]; ok && lm.errorLogs[databaseHash].timestamp != timestamp.UTC().Unix() {
+		go func() {
+			if err := log.Close(); err != nil {
+				slog.Error("Error closing error log", "error", err)
+			}
+		}()
+
+		delete(lm.errorLogs, databaseHash)
+	}
+
+	if _, ok := lm.errorLogs[databaseHash]; !ok {
+		path := fmt.Sprintf("%slogs/error", file.GetDatabaseFileBaseDir(databaseId, branchId))
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		lm.errorLogs[databaseHash] = &ErrorLog{
+			branchId:     branchId,
+			cancel:       cancel,
+			context:      ctx,
+			cluster:      cluster,
+			databaseHash: databaseHash,
+			databaseId:   databaseId,
+			encrypted:    false,
+			mutex:        sync.RWMutex{},
+			path:         path,
+			queue:        make([]*ErrorEntry, 0),
+			tmpFS:        cluster.TmpFS(),
+			timestamp:    timestamp.UTC().Unix(),
+		}
+	}
+
+	return lm.errorLogs[databaseHash]
+}
+
+func (lm *LogManager) Error(entry ErrorLogEntry) error {
+	l := lm.GetErrorLog(
+		entry.Cluster,
+		entry.DatabaseHash,
+		entry.DatabaseID,
+		entry.BranchID,
+	)
+
+	if l == nil {
+		return nil
+	}
+
+	go func() {
+		if err := l.Write(
+			entry.CredentialID,
+			entry.Statement,
+			entry.Error,
+			entry.Latency,
+		); err != nil {
+			slog.Error("Error writing error log", "error", err)
+		}
+	}()
+
+	return nil
 }
 
 func (lm *LogManager) Query(entry QueryLogEntry) error {
@@ -155,6 +238,23 @@ func (lm *LogManager) Run() {
 					}
 
 					delete(lm.queryLogs, l.databaseHash)
+				}
+			}
+
+			// Close error logs that have not been used in the last 5 minutes.
+			for _, l := range lm.errorLogs {
+				l.mutex.Lock()
+				sinceLastLogged := time.Since(l.lastLoggedTime)
+				l.mutex.Unlock()
+
+				if sinceLastLogged > QueryLogManagerFlushThreshold {
+					err := l.Close()
+
+					if err != nil {
+						slog.Error("Error closing error log", "error", err)
+					}
+
+					delete(lm.errorLogs, l.databaseHash)
 				}
 			}
 

--- a/pkg/logs/log_manager_test.go
+++ b/pkg/logs/log_manager_test.go
@@ -112,3 +112,75 @@ func TestLogManager_Error(t *testing.T) {
 		}
 	})
 }
+
+func TestLogManager_GetErrorLogEncrypted(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockEncryptedDatabase(app)
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		if errorLog == nil {
+			t.Fatal("Error log is nil")
+		}
+
+		// For encrypted databases, verify we can write and read error entries
+		err := errorLog.Write(
+			db.Credential.CredentialID,
+			"SELECT * FROM encrypted_test",
+			"no such table: encrypted_test",
+			0.01,
+		)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		errorLog.Flush(true)
+
+		// Verify file was created and has content
+		file, err := errorLog.GetFile()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fileInfo, err := file.Stat()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if fileInfo.Size() == 0 {
+			t.Fatal("Error log file should have content for encrypted database")
+		}
+	})
+}
+
+func TestLogManager_ErrorEncrypted(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockEncryptedDatabase(app)
+
+		// Log an error through the manager for an encrypted database
+		err := app.LogManager.Error(
+			logs.ErrorLogEntry{
+				Cluster:      app.Cluster,
+				DatabaseHash: db.DatabaseKey.DatabaseHash,
+				DatabaseID:   db.DatabaseID,
+				BranchID:     db.DatabaseBranchID,
+				CredentialID: db.Credential.CredentialID,
+				Statement:    "SELECT * FROM encrypted_table",
+				Error:        "no such table: encrypted_table",
+				Latency:      0.02,
+			},
+		)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/pkg/logs/log_manager_test.go
+++ b/pkg/logs/log_manager_test.go
@@ -140,7 +140,11 @@ func TestLogManager_GetErrorLogEncrypted(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		errorLog.Flush(true)
+		err = errorLog.Flush(true)
+
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// Verify file was created and has content
 		file, err := errorLog.GetFile()

--- a/pkg/logs/log_manager_test.go
+++ b/pkg/logs/log_manager_test.go
@@ -72,3 +72,43 @@ func TestLogManager_Run(t *testing.T) {
 		go app.LogManager.Run()
 	})
 }
+
+func TestLogManager_GetErrorLog(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockDatabase(app)
+
+		errorLog := app.LogManager.GetErrorLog(
+			app.Cluster,
+			db.DatabaseKey.DatabaseHash,
+			db.DatabaseID,
+			db.DatabaseBranchID,
+		)
+
+		if errorLog == nil {
+			t.Fatal("Error log is nil")
+		}
+	})
+}
+
+func TestLogManager_Error(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		db := test.MockDatabase(app)
+
+		err := app.LogManager.Error(
+			logs.ErrorLogEntry{
+				Cluster:      app.Cluster,
+				DatabaseHash: db.DatabaseKey.DatabaseHash,
+				DatabaseID:   db.DatabaseID,
+				BranchID:     db.DatabaseBranchID,
+				CredentialID: db.Credential.CredentialID,
+				Statement:    "SELECT * FROM nonexistent",
+				Error:        "no such table: nonexistent",
+				Latency:      0.02,
+			},
+		)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/pkg/server/error_log_cleanup_job.go
+++ b/pkg/server/error_log_cleanup_job.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+
+	"github.com/litebase/litebase/pkg/file"
+)
+
+// CleanupErrorLogJob deletes expired error log files
+// for a specific database branch based on the retention period.
+//
+// Job data parameters:
+//   - database_id: The ID of the database
+//   - branch_id: The ID of the database branch
+//   - cutoff_timestamp: Unix timestamp - files older than this will be deleted
+//   - retention_days: Number of days to retain error logs
+//   - branch_ref_id: The reference ID of the database branch in the system database
+func (app *App) CleanupErrorLogJob(ctx context.Context, data map[string]any) error {
+	// Extract job parameters
+	databaseID, ok := data["database_id"].(string)
+
+	if !ok {
+		return fmt.Errorf("missing or invalid database_id")
+	}
+
+	branchID, ok := data["branch_id"].(string)
+
+	if !ok {
+		return fmt.Errorf("missing or invalid branch_id")
+	}
+
+	cutoffTimestampFloat, ok := data["cutoff_timestamp"].(float64)
+
+	if !ok {
+		return fmt.Errorf("missing or invalid cutoff_timestamp")
+	}
+
+	cutoffTimestamp := int64(cutoffTimestampFloat)
+
+	retentionDaysFloat, ok := data["retention_days"].(float64)
+
+	if !ok {
+		return fmt.Errorf("missing or invalid retention_days")
+	}
+
+	retentionDays := int(retentionDaysFloat)
+
+	slog.Info("Starting error log cleanup",
+		"database_id", databaseID,
+		"branch_id", branchID,
+		"retention_days", retentionDays,
+		"cutoff_timestamp", cutoffTimestamp)
+
+	// Get the database branch to access tiered filesystem
+	branch, err := app.DatabaseManager.GetBranch(databaseID, branchID)
+
+	if err != nil {
+		return fmt.Errorf("failed to get database branch: %w", err)
+	}
+
+	resources := app.DatabaseManager.Resources(branch)
+	tieredFS := resources.FileSystem().FileSystem()
+
+	deletedFiles := 0
+
+	// Get error log directory path
+	logBasePath := fmt.Sprintf("%slogs", file.GetDatabaseFileBaseDir(databaseID, branchID))
+
+	// Read all error log files
+	entries, err := tieredFS.ReadDir(logBasePath)
+
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Error("Failed to read error log directory",
+				"database_id", databaseID,
+				"branch_id", branchID,
+				"directory", logBasePath,
+				"error", err)
+			return fmt.Errorf("failed to read error log directory: %w", err)
+		} else {
+			slog.Debug("Error log directory does not exist, skipping",
+				"database_id", databaseID,
+				"branch_id", branchID)
+			return nil
+		}
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		// Parse timestamp from filename (format: error-{timestamp}.log)
+		filename := entry.Name()
+
+		if len(filename) < 11 || filename[:6] != "error-" || filename[len(filename)-4:] != ".log" {
+			// Not an error log file, skip
+			continue
+		}
+
+		// Extract timestamp between "error-" and ".log"
+		timestampStr := filename[6 : len(filename)-4]
+		timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+
+		if err != nil {
+			slog.Warn("Failed to parse error log file timestamp",
+				"filename", filename,
+				"error", err)
+			continue
+		}
+
+		// Delete if older than cutoff
+		if timestamp < cutoffTimestamp {
+			filePath := fmt.Sprintf("%s/%s", logBasePath, filename)
+
+			if err := tieredFS.Remove(filePath); err != nil {
+				slog.Error("Failed to delete expired error log file",
+					"database_id", databaseID,
+					"branch_id", branchID,
+					"file", filePath,
+					"timestamp", timestamp,
+					"error", err)
+			} else {
+				slog.Debug("Deleted expired error log file",
+					"database_id", databaseID,
+					"branch_id", branchID,
+					"filename", filename,
+					"timestamp", timestamp)
+				deletedFiles++
+			}
+		}
+	}
+
+	slog.Info("Completed error log cleanup",
+		"database_id", databaseID,
+		"branch_id", branchID,
+		"deleted_files", deletedFiles)
+
+	return nil
+}

--- a/pkg/server/error_log_cleanup_job_test.go
+++ b/pkg/server/error_log_cleanup_job_test.go
@@ -1,0 +1,324 @@
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/litebase/litebase/internal/test"
+	"github.com/litebase/litebase/pkg/file"
+	"github.com/litebase/litebase/pkg/server"
+)
+
+func TestCleanupErrorLogJob(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		sysDB, err := app.DatabaseManager.SystemDatabase().DB()
+
+		if err != nil {
+			t.Fatalf("failed to get system database: %v", err)
+		}
+
+		// Helper to create mock error log files
+		createMockErrorLogFile := func(db test.TestDatabase, daysAgo int) {
+			branch, err := app.DatabaseManager.GetBranch(db.DatabaseID, db.DatabaseBranchID)
+
+			if err != nil {
+				t.Fatalf("failed to get database branch: %v", err)
+			}
+
+			resources := app.DatabaseManager.Resources(branch)
+			tieredFS := resources.FileSystem().FileSystem()
+
+			// Create error log directory
+			errorLogPath := fmt.Sprintf("%slogs", file.GetDatabaseFileBaseDir(db.DatabaseID, db.DatabaseBranchID))
+
+			if err := tieredFS.MkdirAll(errorLogPath, 0750); err != nil {
+				t.Fatalf("failed to create error log directory: %v", err)
+			}
+
+			// Create a timestamp-based filename (format: error-{timestamp}.log)
+			timestamp := time.Now().Add(-time.Duration(daysAgo) * 24 * time.Hour).Unix()
+			filename := fmt.Sprintf("%s/error-%d.log", errorLogPath, timestamp)
+
+			// Create the error log file
+			logFile, err := tieredFS.Create(filename)
+
+			if err != nil {
+				t.Fatalf("failed to create error log file: %v", err)
+			}
+
+			if _, err := logFile.Write([]byte("mock error log data")); err != nil {
+				t.Fatalf("failed to write error log data: %v", err)
+			}
+
+			if err := logFile.Close(); err != nil {
+				t.Fatalf("failed to close error log file: %v", err)
+			}
+		}
+
+		// Helper to count error log files
+		countErrorLogFiles := func(db test.TestDatabase) int {
+			branch, err := app.DatabaseManager.GetBranch(db.DatabaseID, db.DatabaseBranchID)
+
+			if err != nil {
+				return 0
+			}
+
+			resources := app.DatabaseManager.Resources(branch)
+			tieredFS := resources.FileSystem().FileSystem()
+
+			errorLogPath := fmt.Sprintf("%slogs", file.GetDatabaseFileBaseDir(db.DatabaseID, db.DatabaseBranchID))
+			entries, err := tieredFS.ReadDir(errorLogPath)
+
+			if err != nil {
+				return 0
+			}
+
+			count := 0
+
+			for _, entry := range entries {
+				if !entry.IsDir() && len(entry.Name()) > 4 && entry.Name()[len(entry.Name())-4:] == ".log" {
+					count++
+				}
+			}
+
+			return count
+		}
+
+		t.Run("SuccessfulCleanup", func(t *testing.T) {
+			db1 := test.MockDatabase(app)
+
+			// Create old error logs (35 days ago - should be deleted with 30-day retention)
+			createMockErrorLogFile(db1, 35)
+			createMockErrorLogFile(db1, 40)
+
+			// Create recent error logs (10 days ago - should be kept)
+			createMockErrorLogFile(db1, 10)
+			createMockErrorLogFile(db1, 5)
+
+			// Get branch ref ID
+			var branchRefID int64
+
+			err := sysDB.QueryRow(`SELECT id FROM database_branches WHERE database_id = ? AND database_branch_id = ?`,
+				db1.DatabaseID, db1.DatabaseBranchID).Scan(&branchRefID)
+
+			if err != nil {
+				t.Fatalf("failed to get branch ref id: %v", err)
+			}
+
+			// Verify files exist before cleanup
+			if count := countErrorLogFiles(db1); count != 4 {
+				t.Fatalf("Expected 4 error log files before cleanup, got %d", count)
+			}
+
+			// Run cleanup job with 30-day retention
+			ctx := context.Background()
+
+			cutoffTime := time.Now().UTC().Add(-30 * 24 * time.Hour)
+
+			data := map[string]any{
+				"database_id":      db1.DatabaseID,
+				"branch_id":        db1.DatabaseBranchID,
+				"cutoff_timestamp": float64(cutoffTime.Unix()),
+				"retention_days":   float64(30),
+				"branch_ref_id":    float64(branchRefID),
+			}
+
+			err = app.CleanupErrorLogJob(ctx, data)
+
+			if err != nil {
+				t.Fatalf("CleanupErrorLogJob failed: %v", err)
+			}
+
+			// Verify only old files were deleted (2 should remain)
+			if count := countErrorLogFiles(db1); count != 2 {
+				t.Errorf("Expected 2 error log files after cleanup, got %d", count)
+			}
+		})
+
+		t.Run("MissingDirectory", func(t *testing.T) {
+			db1 := test.MockDatabase(app)
+
+			// Get branch ref ID
+			var branchRefID int64
+			err := sysDB.QueryRow(`SELECT id FROM database_branches WHERE database_id = ? AND database_branch_id = ?`,
+				db1.DatabaseID, db1.DatabaseBranchID).Scan(&branchRefID)
+
+			if err != nil {
+				t.Fatalf("failed to get branch ref id: %v", err)
+			}
+
+			// Run cleanup (directory doesn't exist, should not error)
+			ctx := context.Background()
+			cutoffTime := time.Now().UTC().Add(-30 * 24 * time.Hour)
+			data := map[string]any{
+				"database_id":      db1.DatabaseID,
+				"branch_id":        db1.DatabaseBranchID,
+				"cutoff_timestamp": float64(cutoffTime.Unix()),
+				"retention_days":   float64(30),
+				"branch_ref_id":    float64(branchRefID),
+			}
+
+			err = app.CleanupErrorLogJob(ctx, data)
+
+			if err != nil {
+				t.Fatalf("CleanupErrorLogJob should not fail for missing directory: %v", err)
+			}
+		})
+
+		t.Run("MissingDatabaseID", func(t *testing.T) {
+			ctx := context.Background()
+			data := map[string]any{
+				"branch_id":        "test-branch",
+				"cutoff_timestamp": float64(123456),
+				"retention_days":   float64(30),
+				"branch_ref_id":    float64(1),
+			}
+
+			err = app.CleanupErrorLogJob(ctx, data)
+
+			if err == nil {
+				t.Error("Expected error for missing database_id")
+			}
+		})
+
+		t.Run("InvalidCutoffTimestamp", func(t *testing.T) {
+			ctx := context.Background()
+			data := map[string]any{
+				"database_id":      "test-db",
+				"branch_id":        "test-branch",
+				"cutoff_timestamp": "not-a-number",
+				"retention_days":   float64(30),
+				"branch_ref_id":    float64(1),
+			}
+
+			err := app.CleanupErrorLogJob(ctx, data)
+
+			if err == nil {
+				t.Error("Expected error for invalid cutoff_timestamp type")
+			}
+		})
+
+		t.Run("NoFilesToCleanup", func(t *testing.T) {
+			db1 := test.MockDatabase(app)
+
+			// Create only recent error logs (within retention period)
+			createMockErrorLogFile(db1, 5)
+			createMockErrorLogFile(db1, 10)
+
+			// Get branch ref ID
+			var branchRefID int64
+			err := sysDB.QueryRow(`SELECT id FROM database_branches WHERE database_id = ? AND database_branch_id = ?`,
+				db1.DatabaseID, db1.DatabaseBranchID).Scan(&branchRefID)
+
+			if err != nil {
+				t.Fatalf("failed to get branch ref id: %v", err)
+			}
+
+			beforeCount := countErrorLogFiles(db1)
+
+			// Run cleanup with 30-day retention
+			ctx := context.Background()
+			cutoffTime := time.Now().UTC().Add(-30 * 24 * time.Hour)
+
+			data := map[string]any{
+				"database_id":      db1.DatabaseID,
+				"branch_id":        db1.DatabaseBranchID,
+				"cutoff_timestamp": float64(cutoffTime.Unix()),
+				"retention_days":   float64(30),
+				"branch_ref_id":    float64(branchRefID),
+			}
+
+			err = app.CleanupErrorLogJob(ctx, data)
+
+			if err != nil {
+				t.Fatalf("CleanupErrorLogJob failed: %v", err)
+			}
+
+			// Verify no files were deleted
+			afterCount := countErrorLogFiles(db1)
+
+			if afterCount != beforeCount {
+				t.Errorf("Expected no files to be deleted, before=%d after=%d", beforeCount, afterCount)
+			}
+		})
+
+		t.Run("InvalidFilenameFormat", func(t *testing.T) {
+			db1 := test.MockDatabase(app)
+
+			branch, err := app.DatabaseManager.GetBranch(db1.DatabaseID, db1.DatabaseBranchID)
+
+			if err != nil {
+				t.Fatalf("failed to get database branch: %v", err)
+			}
+
+			resources := app.DatabaseManager.Resources(branch)
+			tieredFS := resources.FileSystem().FileSystem()
+
+			// Create error log directory
+			errorLogPath := fmt.Sprintf("%slogs", file.GetDatabaseFileBaseDir(db1.DatabaseID, db1.DatabaseBranchID))
+
+			if err := tieredFS.MkdirAll(errorLogPath, 0750); err != nil {
+				t.Fatalf("failed to create error log directory: %v", err)
+			}
+
+			// Create files with invalid formats (should be skipped)
+			invalidFiles := []string{
+				fmt.Sprintf("%s/invalid.log", errorLogPath),
+				fmt.Sprintf("%s/query_log.txt", errorLogPath),
+				fmt.Sprintf("%s/error-notanumber.log", errorLogPath),
+			}
+
+			for _, filename := range invalidFiles {
+				logFile, err := tieredFS.Create(filename)
+
+				if err != nil {
+					t.Fatalf("failed to create invalid log file: %v", err)
+				}
+
+				if err := logFile.Close(); err != nil {
+					t.Fatalf("failed to close invalid log file: %v", err)
+				}
+			}
+
+			// Get branch ref ID
+			var branchRefID int64
+			err = sysDB.QueryRow(`SELECT id FROM database_branches WHERE database_id = ? AND database_branch_id = ?`,
+				db1.DatabaseID, db1.DatabaseBranchID).Scan(&branchRefID)
+
+			if err != nil {
+				t.Fatalf("failed to get branch ref id: %v", err)
+			}
+
+			// Run cleanup
+			ctx := context.Background()
+			cutoffTime := time.Now().UTC().Add(-30 * 24 * time.Hour)
+
+			data := map[string]any{
+				"database_id":      db1.DatabaseID,
+				"branch_id":        db1.DatabaseBranchID,
+				"cutoff_timestamp": float64(cutoffTime.Unix()),
+				"retention_days":   float64(30),
+				"branch_ref_id":    float64(branchRefID),
+			}
+
+			err = app.CleanupErrorLogJob(ctx, data)
+
+			if err != nil {
+				t.Fatalf("CleanupErrorLogJob should not fail with invalid filenames: %v", err)
+			}
+
+			// Verify invalid files still exist (should be skipped)
+			entries, err := tieredFS.ReadDir(errorLogPath)
+
+			if err != nil {
+				t.Fatalf("failed to read error log directory: %v", err)
+			}
+
+			if len(entries) != 3 {
+				t.Errorf("Expected 3 invalid files to remain, got %d", len(entries))
+			}
+		})
+	})
+}

--- a/pkg/server/error_log_cleanup_task.go
+++ b/pkg/server/error_log_cleanup_task.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/litebase/litebase/pkg/queue"
+)
+
+// EnqueueErrorLogCleanupJobs queries the system database for branches with
+// error logs enabled and dispatches cleanup jobs for expired error logs.
+func (app *App) EnqueueErrorLogCleanupJobs(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	db, err := app.DatabaseManager.SystemDatabase().DB()
+
+	if err != nil {
+		slog.Error("Failed to get system database for error log cleanup", "error", err)
+		return err
+	}
+
+	slog.Info("Starting to enqueue error log cleanup jobs")
+
+	pageSize := 1000
+	offset := 0
+
+	for {
+		// Query all branches (error logs are enabled by default)
+		// We'll use a default retention of 30 days if not specified
+		rows, err := db.Query(`
+			SELECT 
+				db.database_id,
+				db.database_branch_id,
+				db.id as branch_ref_id
+			FROM database_branches db
+			LIMIT ? OFFSET ?
+		`, pageSize, offset)
+
+		if err != nil {
+			slog.Error("Failed to query branches for error log cleanup", "error", err)
+			return err
+		}
+
+		count := 0
+
+		for rows.Next() {
+			count++
+
+			var databaseID, branchID string
+			var branchRefID int64
+
+			if err := rows.Scan(&databaseID, &branchID, &branchRefID); err != nil {
+				slog.Error("Failed to scan error log cleanup row", "error", err)
+				continue
+			}
+
+			// Default retention: 30 days for error logs
+			retentionDays := 30
+			cutoffTime := time.Now().UTC().Add(-time.Duration(retentionDays) * 24 * time.Hour)
+			cutoffTimestamp := cutoffTime.Unix()
+
+			// Dispatch a cleanup job for this branch
+			_, err := app.QueueDispatcher.DispatchJob(
+				"CleanupErrorLogJob",
+				map[string]any{
+					"database_id":      databaseID,
+					"branch_id":        branchID,
+					"cutoff_timestamp": cutoffTimestamp,
+					"retention_days":   retentionDays,
+					"branch_ref_id":    branchRefID,
+				},
+				queue.WithKey(fmt.Sprintf("cleanup-error-log:%s:%s", databaseID, branchID)),
+				queue.Unique(),
+			)
+
+			if err != nil {
+				slog.Error("Failed to dispatch error log cleanup job",
+					"database_id", databaseID,
+					"branch_id", branchID,
+					"error", err)
+				// Continue processing other branches
+			} else {
+				slog.Debug("Dispatched error log cleanup job",
+					"database_id", databaseID,
+					"branch_id", branchID,
+					"retention_days", retentionDays)
+			}
+		}
+
+		if err := rows.Close(); err != nil {
+			slog.Error("Failed to close rows", "error", err)
+			return err
+		}
+
+		// If we didn't get a full page, we're done
+		if count < pageSize {
+			break
+		}
+
+		offset += pageSize
+	}
+
+	slog.Info("Finished enqueueing error log cleanup jobs")
+
+	return nil
+}

--- a/pkg/server/error_log_cleanup_task_test.go
+++ b/pkg/server/error_log_cleanup_task_test.go
@@ -1,0 +1,141 @@
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/litebase/litebase/internal/test"
+	"github.com/litebase/litebase/pkg/server"
+)
+
+func TestEnqueueErrorLogCleanupJobs(t *testing.T) {
+	test.RunWithApp(t, func(app *server.App) {
+		sysDB, err := app.DatabaseManager.SystemDatabase().DB()
+
+		if err != nil {
+			t.Fatalf("failed to get system db: %v", err)
+		}
+
+		// Helper to count cleanup jobs for a specific branch
+		countCleanupJobsForBranch := func(databaseID, branchID string) int {
+			var count int
+
+			err := sysDB.QueryRow(`
+				SELECT COUNT(*) 
+				FROM queued_jobs 
+				WHERE name = 'CleanupErrorLogJob' 
+				AND key = ?
+			`, fmt.Sprintf("cleanup-error-log:%s:%s", databaseID, branchID)).Scan(&count)
+
+			if err != nil {
+				t.Fatalf("failed to count jobs: %v", err)
+			}
+
+			return count
+		}
+
+		t.Run("EnqueueForAllBranches", func(t *testing.T) {
+			// Clean up any existing jobs
+			_, err := sysDB.Exec(`DELETE FROM queued_jobs WHERE name = 'CleanupErrorLogJob'`)
+
+			if err != nil {
+				t.Fatalf("failed to clean up existing jobs: %v", err)
+			}
+
+			// Create test databases
+			db1 := test.MockDatabase(app)
+			db2 := test.MockDatabase(app)
+
+			// Run the task
+			ctx := context.Background()
+			err = app.EnqueueErrorLogCleanupJobs(ctx)
+
+			if err != nil {
+				t.Fatalf("EnqueueErrorLogCleanupJobs failed: %v", err)
+			}
+
+			// Verify jobs were created
+			if count := countCleanupJobsForBranch(db1.DatabaseID, db1.DatabaseBranchID); count != 1 {
+				t.Errorf("Expected 1 cleanup job for db1, got %d", count)
+			}
+
+			if count := countCleanupJobsForBranch(db2.DatabaseID, db2.DatabaseBranchID); count != 1 {
+				t.Errorf("Expected 1 cleanup job for db2, got %d", count)
+			}
+		})
+
+		t.Run("UniqueJobDispatch", func(t *testing.T) {
+			// Clean up any existing jobs
+			_, err := sysDB.Exec(`DELETE FROM queued_jobs WHERE name = 'CleanupErrorLogJob'`)
+
+			if err != nil {
+				t.Fatalf("failed to clean up existing jobs: %v", err)
+			}
+
+			db1 := test.MockDatabase(app)
+
+			// Run the task twice
+			ctx := context.Background()
+
+			err = app.EnqueueErrorLogCleanupJobs(ctx)
+
+			if err != nil {
+				t.Fatalf("First EnqueueErrorLogCleanupJobs failed: %v", err)
+			}
+
+			err = app.EnqueueErrorLogCleanupJobs(ctx)
+
+			if err != nil {
+				t.Fatalf("Second EnqueueErrorLogCleanupJobs failed: %v", err)
+			}
+
+			// Should still only have 1 job (unique key prevents duplicates)
+			if count := countCleanupJobsForBranch(db1.DatabaseID, db1.DatabaseBranchID); count != 1 {
+				t.Errorf("Expected 1 unique job after running task twice, got %d", count)
+			}
+		})
+
+		t.Run("Pagination", func(t *testing.T) {
+			// Clean up any existing jobs
+			_, err := sysDB.Exec(`DELETE FROM queued_jobs WHERE name = 'CleanupErrorLogJob'`)
+
+			if err != nil {
+				t.Fatalf("failed to clean up existing jobs: %v", err)
+			}
+
+			// Create multiple databases to test pagination
+			dbs := make([]test.TestDatabase, 5)
+
+			for i := range dbs {
+				dbs[i] = test.MockDatabase(app)
+			}
+
+			// Run the task
+			ctx := context.Background()
+			err = app.EnqueueErrorLogCleanupJobs(ctx)
+
+			if err != nil {
+				t.Fatalf("EnqueueErrorLogCleanupJobs failed: %v", err)
+			}
+
+			// Verify all databases got cleanup jobs
+			for i, db := range dbs {
+				if countCleanupJobsForBranch(db.DatabaseID, db.DatabaseBranchID) != 1 {
+					t.Errorf("Expected cleanup job for database %d", i)
+				}
+			}
+		})
+
+		t.Run("ContextCancellation", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // Cancel immediately
+
+			err = app.EnqueueErrorLogCleanupJobs(ctx)
+
+			if err == nil {
+				t.Error("Expected error with cancelled context, got nil")
+			}
+		})
+	})
+}

--- a/pkg/server/queue_jobs.go
+++ b/pkg/server/queue_jobs.go
@@ -53,4 +53,16 @@ func (app *App) InitQueueJobs() {
 	if err != nil {
 		panic(err)
 	}
+
+	// Register error log cleanup job with retries and timeout for file operations.
+	err = app.QueueWorkerPool.RegisterJob(
+		"CleanupErrorLogJob",
+		app.CleanupErrorLogJob,
+		queue.WithRetries(3, 5*time.Minute),
+		queue.WithTimeout(30*time.Minute),
+	)
+
+	if err != nil {
+		panic(err)
+	}
 }

--- a/pkg/server/scheduled_tasks.go
+++ b/pkg/server/scheduled_tasks.go
@@ -103,6 +103,24 @@ func (app *App) InitScheduledTasks() {
 		slog.Error("Failed to register CleanupExpiredQueryLogs task", "error", err)
 	}
 
+	// Cleanup old error logs (critical - prevents storage bloat):
+	// Runs daily at 05:30 to find and cleanup expired error logs.
+	// Error logs older than retention_days are deleted from storage.
+	// Daily execution ensures old error data doesn't accumulate indefinitely.
+	// Critical because error log storage can grow quickly and affect costs.
+	err = app.Scheduler.RegisterTask(
+		"CleanupExpiredErrorLogs",
+		func(ctx context.Context) error { return app.EnqueueErrorLogCleanupJobs(ctx) },
+		scheduler.WithSchedule(scheduler.Daily),
+		scheduler.WithTime("05:30"),
+		scheduler.WithCritical(),   // Will catch up after downtime to prevent storage bloat
+		scheduler.WithoutOverlap(), // Don't run concurrent cleanup operations
+	)
+
+	if err != nil {
+		slog.Error("Failed to register CleanupExpiredErrorLogs task", "error", err)
+	}
+
 	// NON-CRITICAL TASKS - These will be skipped if missed during downtime:
 	// Informational or monitoring tasks that don't affect data integrity.
 


### PR DESCRIPTION
This pull request introduces a new API endpoint for retrieving error logs for a specific database and branch, and updates the OpenAPI documentation and test cases accordingly. The changes include enhancements to the API specification and minor updates to test data.

**API enhancements:**

* Added a new endpoint `GET /v1/databases/{databaseName}/branches/{branchName}/errors` to list error logs for a given database and branch, including support for filtering by start and end timestamps, and documented possible responses and security requirements.
* Added a new OpenAPI tag `ErrorLog` with the description "Error performance and usage metrics" to categorize the new endpoint.

**Test case and data updates:**

* Updated various test cases in `api/generated_open_api_test_cases.json` to use new database names and query IDs, ensuring alignment with the latest test data and avoiding conflicts. [[1]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L319-R319) [[2]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L344-R344) [[3]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L395-R395) [[4]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L433-R433) [[5]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L475-R475) [[6]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L495-R495) [[7]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L568-R568) [[8]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L588-R588) [[9]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L691-R691) [[10]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L711-R711) [[11]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L799-R799) [[12]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L819-R819) [[13]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L896-R896) [[14]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L916-R916) [[15]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L973-R973) [[16]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L993-R993) [[17]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1078-R1078) [[18]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1098-R1098) [[19]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1148-R1148) [[20]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1168-R1168) [[21]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1224-R1224) [[22]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1263-R1263) [[23]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1321-R1321) [[24]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1341-R1341) [[25]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1395-R1395) [[26]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1415-R1415) [[27]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1513-R1513) [[28]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1533-R1533) [[29]](diffhunk://#diff-9237201336c3d14e659c022390b92c70698dec8db8f9c36511f576ee13989a02L1621-R1621)