### PR TITLE
Bump Go to 1.26 and update deps/workflows

### DIFF
--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -24,7 +24,7 @@ inputs:
   go_version:
     description: 'Go version to use'
     required: false
-    default: '1.25'
+    default: '1.26'
 
 outputs:
   archive_name:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
         description: "Go version to use"
         required: false
         type: string
-        default: "1.25"
+        default: "1.26"
     outputs:
       version:
         description: 'Version extracted from tag or "dev"'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,4 +26,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.4
+          version: v2.9.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.4

--- a/.github/workflows/openapi-generator.yml
+++ b/.github/workflows/openapi-generator.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache-dependency-path: go.sum
 
       - name: Generate OpenAPI specification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       project_name: "litebase"
       build_target: "./cmd/litebase"
-          go_version: "1.26"
+      go_version: "1.26"
 
   build-docker:
     needs: [get-version, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       project_name: "litebase"
       build_target: "./cmd/litebase"
-      go_version: "1.25"
+          go_version: "1.26"
 
   build-docker:
     needs: [get-version, build]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache-dependency-path: go.sum
 
       - name: Run tests

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/litebase/litebase
 
-go 1.25
+go 1.26
 
 require (
-	github.com/aws/aws-sdk-go v1.55.7
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67
 	github.com/charmbracelet/bubbles/v2 v2.0.0-beta.1
@@ -13,6 +12,7 @@ require (
 	github.com/charmbracelet/huh v0.7.0
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta1
 	github.com/charmbracelet/x/term v0.2.1
+	github.com/go-co-op/gocron/v2 v2.19.0
 	github.com/go-playground/validator/v10 v10.27.0
 	github.com/johannesboyne/gofakes3 v0.0.0-20250402064820-d479899d8cbe
 	github.com/joho/godotenv v1.5.1
@@ -22,12 +22,11 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go v1.55.7 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/go-co-op/gocron/v2 v2.19.0 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/yuin/goldmark-emoji v1.0.5/go.mod h1:tTkZEbwu5wkPmgTcitqddVxY9osFZiav
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.shabbyrobe.org/gocovmerge v0.0.0-20230507111327-fa4f82cfbf4d h1:Ns9kd1Rwzw7t0BR8XMphenji4SmIoNZPn8zhYmaVKP8=
 go.shabbyrobe.org/gocovmerge v0.0.0-20230507111327-fa4f82cfbf4d/go.mod h1:92Uoe3l++MlthCm+koNi0tcUCX3anayogF0Pa/sp24k=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v4 v4.0.0-rc.1 h1:4J1+yLKUIPGexM/Si+9d3pij4hdc7aGO04NhrElqXbY=
 go.yaml.in/yaml/v4 v4.0.0-rc.1/go.mod h1:CBdeces52/nUXndfQ5OY8GEQuNR9uEEOJPZj/Xq5IzU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
Upgrade project to Go 1.26 by updating the default Go version in the build action, workflows (build, tests, openapi-generator, release), and Dockerfile.local, and by setting go 1.26 in go.mod. Tidy go.mod: promote github.com/go-co-op/gocron to a direct dependency, mark github.com/aws/aws-sdk-go as indirect, and remove an unused indirect testify entry. These changes align CI, local build image, and module settings with Go 1.26.